### PR TITLE
Fix endpoint on port range for python2

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     # Python 3
     from http.server import HTTPServer
+import socket
 import logging
 import os
 import prometheus_client
@@ -76,7 +77,9 @@ def SetupPrometheusEndpointOnPortRange(port_range, addr=''):
     for port in port_range:
         try:
             httpd = HTTPServer((addr, port), prometheus_client.MetricsHandler)
-        except OSError:
+        except (OSError, socket.error):
+            # Python 2 raises socket.error, in Python 3 socket.error is an
+            # alias for OSError
             continue  # Try next port
         thread = PrometheusEndpointServer(httpd)
         thread.daemon = True

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+from django_prometheus.exports import SetupPrometheusEndpointOnPortRange
+import unittest
+
+
+class ExportTest(unittest.TestCase):
+    def testPortRange(self):
+        port_range = [8000, 8001]
+        SetupPrometheusEndpointOnPortRange(port_range)
+        SetupPrometheusEndpointOnPortRange(port_range)
+
+if __name__ == 'main':
+    unittest.main()


### PR DESCRIPTION
When attempting to use this with python 2, I ran in to a little snag. The following patch fixes the issue.