### PR TITLE
Fix endpoint on port range for python2

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     # Python 3
     from http.server import HTTPServer
+import socket
 import logging
 import os
 import prometheus_client
@@ -76,7 +77,9 @@ def SetupPrometheusEndpointOnPortRange(port_range, addr=''):
     for port in port_range:
         try:
             httpd = HTTPServer((addr, port), prometheus_client.MetricsHandler)
-        except OSError:
+        except (OSError, socket.error):
+            # Python 2 raises socket.error, in Python 3 socket.error is an
+            # alias for OSError
             continue  # Try next port
         thread = PrometheusEndpointServer(httpd)
         thread.daemon = True

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python
-from django_prometheus.exports import SetupPrometheusEndpointOnPortRange
+import socket
 import unittest
+
+from mock import patch, call, ANY, MagicMock
+
+from django_prometheus.exports import SetupPrometheusEndpointOnPortRange
 
 
 class ExportTest(unittest.TestCase):
-    def testPortRange(self):
+    @patch('django_prometheus.exports.HTTPServer')
+    def testPortRange(self, httpserver_mock):
+        httpserver_mock.side_effect = [socket.error, MagicMock()]
         port_range = [8000, 8001]
         SetupPrometheusEndpointOnPortRange(port_range)
-        SetupPrometheusEndpointOnPortRange(port_range)
+
+        expected_calls = [
+            call(('', 8000), ANY),
+            call(('', 8001), ANY),
+        ]
+        self.assertEqual(httpserver_mock.mock_calls, expected_calls)
+
 
 if __name__ == 'main':
     unittest.main()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+from django_prometheus.exports import SetupPrometheusEndpointOnPortRange
+import unittest
+
+
+class ExportTest(unittest.TestCase):
+    def testPortRange(self):
+        port_range = [8000, 8001]
+        SetupPrometheusEndpointOnPortRange(port_range)
+        SetupPrometheusEndpointOnPortRange(port_range)
+
+if __name__ == 'main':
+    unittest.main()


### PR DESCRIPTION
This builds on #15 and addresses feedback to mock HTTPServer
so that tests don't attempt to allocate real ports.