### PR TITLE
⚠️ Celery instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,17 @@ there are unapplied migrations.
 You can enable the ``celery_queued_tasks`` counter in your settings module:
 
 ```python
-DJANGO_PROMETHEUS_MONITOR_CELERY = True
+PROMETHEUS_MONITOR_CELERY = True
 ````
 
 If you use the `push-gateway <https://prometheus.io/docs/instrumenting/pushing/>`_
 you can enable per-task metrics by specifying the push server's hostname and port:
 
 ```python
-DJANGO_PROMETHEUS_PUSH_GATEWAY = 'localhost:9091'
+PROMETHEUS_PUSH_GATEWAY = 'localhost:9091'
 ```
 
-The default job ID is `celery` and may be customized by setting ``DJANGO_PROMETHEUS_PUSH_GATEWAY_JOB_ID``
+The default job ID is `celery` and may be customized by setting ``PROMETHEUS_PUSH_GATEWAY_JOB_ID``
 
 More advanced users may wish to customize the job ID or push gateway server per-task. This can be done
 by calling the `celery.task_prerun_listener` and `celery.task_postrun_listener` functions from your

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ are exported, `django_migrations_applied_by_connection` and
 `django_migrations_unapplied_by_connection`. You may want to alert if
 there are unapplied migrations.
 
+### Monitoring Celery tasks
+
+You can enable the ``celery_queued_tasks`` counter in your settings module:
+
+```python
+DJANGO_PROMETHEUS_MONITOR_CELERY = True
+````
+
 ### Monitoring and aggregating the metrics
 
 Prometheus is quite easy to set up. An example prometheus.conf to

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ You can enable the ``celery_queued_tasks`` counter in your settings module:
 DJANGO_PROMETHEUS_MONITOR_CELERY = True
 ````
 
+If you use the `push-gateway <https://prometheus.io/docs/instrumenting/pushing/>`_
+you can enable per-task metrics by specifying the push server's hostname and port:
+
+```python
+DJANGO_PROMETHEUS_PUSH_GATEWAY = 'localhost:9091'
+```
+
+The default job ID is `celery` and may be customized by setting ``DJANGO_PROMETHEUS_PUSH_GATEWAY_JOB_ID``
+
+More advanced users may wish to customize the job ID or push gateway server per-task. This can be done
+by calling the `celery.task_prerun_listener` and `celery.task_postrun_listener` functions from your
+custom handlers using the desired `push_gateway` and `job_id` arguments.
+
+
 ### Monitoring and aggregating the metrics
 
 Prometheus is quite easy to set up. An example prometheus.conf to

--- a/django_prometheus/apps.py
+++ b/django_prometheus/apps.py
@@ -30,3 +30,8 @@ class DjangoPrometheusConfig(AppConfig):
         if getattr(settings, 'DJANGO_PROMETHEUS_MONITOR_CELERY', False):
             from . import celery
             celery.register_metrics()
+
+            push_gateway = getattr(settings, 'DJANGO_PROMETHEUS_PUSH_GATEWAY', None)
+            if push_gateway:
+                job_id = getattr(settings, 'DJANGO_PROMETHEUS_PUSH_GATEWAY_JOB_ID', 'celery')
+                celery.enable_push_gateway(push_gateway, job_id)

--- a/django_prometheus/apps.py
+++ b/django_prometheus/apps.py
@@ -1,6 +1,9 @@
 from django.apps import AppConfig
+from django.conf import settings
+
 from django_prometheus.exports import SetupPrometheusExportsFromConfig
 from django_prometheus.migrations import ExportMigrations
+
 # unused import to force instantiating the metric objects at startup.
 import django_prometheus
 
@@ -20,3 +23,10 @@ class DjangoPrometheusConfig(AppConfig):
         """
         SetupPrometheusExportsFromConfig()
         ExportMigrations()
+
+        # Celery not longer reliably has something like `djcelery` in INSTALLED_APPS
+        # so we'll use a setting to trigger generic registry. This also allows users
+        # register the task listener only for specific senders.
+        if getattr(settings, 'DJANGO_PROMETHEUS_MONITOR_CELERY', False):
+            from . import celery
+            celery.register_metrics()

--- a/django_prometheus/apps.py
+++ b/django_prometheus/apps.py
@@ -27,11 +27,11 @@ class DjangoPrometheusConfig(AppConfig):
         # Celery not longer reliably has something like `djcelery` in INSTALLED_APPS
         # so we'll use a setting to trigger generic registry. This also allows users
         # register the task listener only for specific senders.
-        if getattr(settings, 'DJANGO_PROMETHEUS_MONITOR_CELERY', False):
+        if getattr(settings, 'PROMETHEUS_MONITOR_CELERY', False):
             from . import celery
             celery.register_metrics()
 
-            push_gateway = getattr(settings, 'DJANGO_PROMETHEUS_PUSH_GATEWAY', None)
+            push_gateway = getattr(settings, 'PROMETHEUS_PUSH_GATEWAY', None)
             if push_gateway:
-                job_id = getattr(settings, 'DJANGO_PROMETHEUS_PUSH_GATEWAY_JOB_ID', 'celery')
+                job_id = getattr(settings, 'PROMETHEUS_PUSH_GATEWAY_JOB_ID', 'celery')
                 celery.enable_push_gateway(push_gateway, job_id)

--- a/django_prometheus/celery.py
+++ b/django_prometheus/celery.py
@@ -9,12 +9,12 @@ There are two levels of monitoring available:
    use of the Prometheus push-gateway to aggregate the metrics sent from the transient
    worker processes.
 
-   Set the ``DJANGO_PROMETHEUS_PUSH_GATEWAY`` setting to the hostname and port which
+   Set the ``PROMETHEUS_PUSH_GATEWAY`` setting to the hostname and port which
    your pushgateway server is running on::
 
-    DJANGO_PROMETHEUS_PUSH_GATEWAY = 'localhost:9091'
+    PROMETHEUS_PUSH_GATEWAY = 'localhost:9091'
 
-   The job ID can be customized by setting `DJANGO_PROMETHEUS_PUSH_GATEWAY_JOB_ID`
+   The job ID can be customized by setting `PROMETHEUS_PUSH_GATEWAY_JOB_ID`
 
    See https://prometheus.io/docs/instrumenting/pushing/ for more information about
    the push-gateway.

--- a/django_prometheus/celery.py
+++ b/django_prometheus/celery.py
@@ -1,19 +1,108 @@
 # encoding: utf-8
+"""Celery metrics for Prometheus
+
+There are two levels of monitoring available:
+
+1. The `celery_queued_tasks` counter which is incremented each time a task is queued
+   and is exposed along with all of the other metrics collected by django-prometheus
+2. Since Celery tasks execute in a separate process, collecting their metrics requires
+   use of the Prometheus push-gateway to aggregate the metrics sent from the transient
+   worker processes.
+
+   Set the ``DJANGO_PROMETHEUS_PUSH_GATEWAY`` setting to the hostname and port which
+   your pushgateway server is running on::
+
+    DJANGO_PROMETHEUS_PUSH_GATEWAY = 'localhost:9091'
+
+   The job ID can be customized by setting `DJANGO_PROMETHEUS_PUSH_GATEWAY_JOB_ID`
+
+   See https://prometheus.io/docs/instrumenting/pushing/ for more information about
+   the push-gateway.
+"""
 
 from __future__ import absolute_import, division, print_function
 
-from celery.signals import after_task_publish
-from prometheus_client import Counter
+from functools import partial
+from timeit import default_timer
+
+from celery.signals import after_task_publish, task_postrun, task_prerun
+from celery.utils.log import get_task_logger
+from prometheus_client import CollectorRegistry, Counter, Summary, pushadd_to_gateway
 
 celery_queued_tasks = Counter(
     'celery_queued_tasks',
     'Tasks submitted to the Celery queue',
     ('exchange', 'routing_key', 'task'))
 
+# We'll use this for every metric which is going to be pushed rather than scraped:
+push_registry = CollectorRegistry()
+
+celery_tasks_started = Counter(
+    'celery_tasks_started',
+    'Tasks started by a Celery worker',
+    ('task', ),
+    registry=push_registry
+)
+
+celery_tasks_completed = Counter(
+    'celery_tasks_completed',
+    'Celery tasks which completed',
+    ('task', 'state'),
+    registry=push_registry
+)
+
+celery_tasks_revoked = Counter(
+    'celery_tasks_revoked',
+    'Celery tasks which were revoked or terminated',
+    ('task', 'terminated', 'expired', 'signal'),
+    registry=push_registry
+)
+
+celery_tasks_elapsed_time = Summary(
+    'celery_tasks_elapsed_time',
+    'Celery tasks cumulative elapsed time',
+    ('task', 'state'),
+    registry=push_registry
+)
+
+# We need to record when a task started so we can record the elapsed time
+# when it completes:
+TASK_START_TIMES = {}
+
 
 def after_task_publish_listener(body, exchange, routing_key, *args, **kwargs):
     celery_queued_tasks.labels(exchange, routing_key, body['task']).inc()
 
 
+def task_prerun_listener(task_id=None, task=None, push_gateway=None, job_id=None, **kwargs):
+    TASK_START_TIMES[task_id] = default_timer()
+    celery_tasks_started.labels(task.name).inc()
+
+    pushadd_to_gateway(push_gateway, job=job_id, registry=push_registry)
+
+
+def task_postrun_listener(task_id=None, task=None, state=None, push_gateway=None, job_id=None, **kwargs):
+    if task_id not in TASK_START_TIMES:
+        get_task_logger().error('task_postrun called for unregistered task ID: %s', task_id)
+        return
+
+    elapsed_time = default_timer() - TASK_START_TIMES.pop(task_id)
+
+    celery_tasks_completed.labels(task.name, state).inc()
+    celery_tasks_elapsed_time.labels(task.name, state).observe(elapsed_time)
+
+    pushadd_to_gateway(push_gateway, job=job_id, registry=push_registry)
+
+
 def register_metrics():
     after_task_publish.connect(after_task_publish_listener)
+
+
+def enable_push_gateway(push_gateway, job_id):
+    # We'll use `partial` to bind the passed `push_gateway` and `job_id` values in the listeners
+    # so we don't need to stash them in a global variable. Note the necessity to use weak=False to avoid our
+    # partial functions being garbage-collected after this function returns:
+    task_prerun.connect(partial(task_prerun_listener, push_gateway=push_gateway, job_id=job_id),
+                        weak=False)
+    task_postrun.connect(partial(task_postrun_listener, push_gateway=push_gateway, job_id=job_id),
+                         weak=False)

--- a/django_prometheus/celery.py
+++ b/django_prometheus/celery.py
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function
+
+from celery.signals import after_task_publish
+from prometheus_client import Counter
+
+celery_queued_tasks = Counter(
+    'celery_queued_tasks',
+    'Tasks submitted to the Celery queue',
+    ('exchange', 'routing_key', 'task'))
+
+
+def after_task_publish_listener(body, exchange, routing_key, *args, **kwargs):
+    celery_queued_tasks.labels(exchange, routing_key, body['task']).inc()
+
+
+def register_metrics():
+    after_task_publish.connect(after_task_publish_listener)


### PR DESCRIPTION
Warning: this has only been lightly tested – I'm opening it to get feedback but have not yet run it long enough to say the metrics & labels couldn't use some tweaking. This adds a simple metric for the number of enqueued tasks and allows actual task execution to be monitoring as long as you have the push-gateway available.

One question was whether the push-gateway should be recommended as an option for handling other things like multi-process WSGI servers where we're stuck managing a potentially large number of processes which regularly recycle.
