### PR TITLE
Add PROMETHEUS_EXPORT_MIGRATIONS (True) setting

### DIFF
--- a/django_prometheus/apps.py
+++ b/django_prometheus/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 from django_prometheus.exports import SetupPrometheusExportsFromConfig
 from django_prometheus.migrations import ExportMigrations
 # unused import to force instantiating the metric objects at startup.
@@ -19,4 +20,5 @@ class DjangoPrometheusConfig(AppConfig):
         are usually short-lived), but can be useful for debugging.
         """
         SetupPrometheusExportsFromConfig()
-        ExportMigrations()
+        if getattr(settings, 'PROMETHEUS_EXPORT_MIGRATIONS', True):
+            ExportMigrations()


### PR DESCRIPTION
The early database access (add application configuration time) in ExportMigrations() caused some trouble for us during testing (since the testing database won't have been started yet at this point), so here's a setting to disable it.