### PR TITLE
Compatibility with prometheus-client>=0.0.15

### DIFF
--- a/django_prometheus/db/common.py
+++ b/django_prometheus/db/common.py
@@ -28,7 +28,7 @@ class ExceptionCounterByType(object):
     def __exit__(self, typ, value, traceback):
         if typ is not None:
             self._labels.update({self._type_label: typ.__name__})
-            self._counter.labels(self._labels).inc()
+            self._counter.labels(**self._labels).inc()
 
 
 class DatabaseWrapperMixin(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.4
 pep8>=1.6.2
-prometheus-client>=0.0.13
+prometheus-client>=0.0.15
 pip-prometheus>=1.0.0
 mock>=1.0.1
 mysqlclient


### PR DESCRIPTION
Fixes #32. I chose to simply require prometheus-client>=0.0.15, rather than try to continue to support down to 0.0.13.