### PR TITLE
Support multiprocess collection

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -1,5 +1,7 @@
 from django.http import HttpResponse
 from django.conf import settings
+from prometheus_client import multiprocess
+
 try:
     # Python 2
     from BaseHTTPServer import HTTPServer
@@ -105,7 +107,10 @@ def ExportToDjangoView(request):
 
     You can use django_prometheus.urls to map /metrics to this view.
     """
-    metrics_page = prometheus_client.generate_latest()
+    registry = prometheus_client.CollectorRegistry()
+    if 'prometheus_multiproc_dir' in os.environ:
+        multiprocess.MultiProcessCollector(registry)
+    metrics_page = prometheus_client.generate_latest(registry)
     return HttpResponse(
         metrics_page,
         content_type=prometheus_client.CONTENT_TYPE_LATEST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.4
 pep8>=1.6.2
--e git+https://github.com/prometheus/client_python@7fb50581ec03fe9f320dcecfcba0952b683d279c#egg=prometheus_client
+prometheus-client>=0.0.21
 pip-prometheus>=1.0.0
 mock>=1.0.1
 mysqlclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.4
 pep8>=1.6.2
-prometheus-client>=0.0.15
+-e git+https://github.com/prometheus/client_python@7fb50581ec03fe9f320dcecfcba0952b683d279c#egg=prometheus_client
 pip-prometheus>=1.0.0
 mock>=1.0.1
 mysqlclient


### PR DESCRIPTION
`gunicorn_config.py`

```
from prometheus_client import multiprocess


def child_exit(server, worker):
    multiprocess.mark_process_dead(worker.pid)

workers = 5
```

Start command:

```
prometheus_multiproc_dir=metrics gunicorn -e 'prometheus_multiproc_dir=metrics' -c gunicorn_config.py example_project.wsgi
```

This makes the `/metrics` return an aggregate of the workers.