### PR TITLE
Do not read request.body in middleware

### DIFF
--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -119,7 +119,8 @@ class PrometheusAfterMiddleware(MiddlewareMixin):
         requests_by_transport.labels(transport).inc()
         if request.is_ajax():
             ajax_requests.inc()
-        requests_body_bytes.observe(int(request.META.get('CONTENT_LENGTH') or 0))
+        content_length = int(request.META.get('CONTENT_LENGTH') or 0)
+        requests_body_bytes.observe(content_length)
         request.prometheus_after_middleware_event = Time()
 
     def process_view(self, request, view_func, *view_args, **view_kwargs):

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -119,7 +119,7 @@ class PrometheusAfterMiddleware(MiddlewareMixin):
         requests_by_transport.labels(transport).inc()
         if request.is_ajax():
             ajax_requests.inc()
-        requests_body_bytes.observe(len(request.body))
+        requests_body_bytes.observe(int(request.META.get('CONTENT_LENGTH') or 0))
         request.prometheus_after_middleware_event = Time()
 
     def process_view(self, request, view_func, *view_args, **view_kwargs):


### PR DESCRIPTION
Before this, in Django 1.7, if you submit a form with an `<input type="file" >`then reading `request.body` generates and error:

`RawPostDataException`
`You cannot access body after reading from request's data stream`

This uses `request.META['CONTENT_LENGTH']` instead of `request.body` to determine the request length in order to avoid this error.