### PR TITLE
Use core.REGISTRY when in single process mode

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -107,9 +107,11 @@ def ExportToDjangoView(request):
 
     You can use django_prometheus.urls to map /metrics to this view.
     """
-    registry = prometheus_client.CollectorRegistry()
     if 'prometheus_multiproc_dir' in os.environ:
+        registry = prometheus_client.CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
+    else:
+        registry = prometheus_client.REGISTRY
     metrics_page = prometheus_client.generate_latest(registry)
     return HttpResponse(
         metrics_page,


### PR DESCRIPTION
Fixes https://github.com/korfuri/django-prometheus/issues/53

The change to support multiprocess broke the single process exposition as instead of using the default `core.REGISTRY` for `generate_latest()` registry argument, it was using a new blank `CollectorRegistry()`.