### PR TITLE
Use the default registry in exports.exportToDjangoView

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -107,7 +107,7 @@ def ExportToDjangoView(request):
 
     You can use django_prometheus.urls to map /metrics to this view.
     """
-    registry = prometheus_client.CollectorRegistry()
+    registry = prometheus_client.REGISTRY
     if 'prometheus_multiproc_dir' in os.environ:
         multiprocess.MultiProcessCollector(registry)
     metrics_page = prometheus_client.generate_latest(registry)


### PR DESCRIPTION
This seems to me to be a mistake introduced in #46. `prometheus_client.CollectorRegistry()` just returns a new (empty) registry, so that the django view does not contain any metrics anymore (I tested in normal single process mode)

This change reverts to using the default registry.

I haven't tested multiprocess mode so I can't confirm that it still works.