### PR TITLE
Add custom latency buckets from Settings variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ urlpatterns = [
 ]
 ```
 
+### Configuration
+Prometheus uses Histogram based grouping for monitoring latencies. The default
+buckets are here: https://github.com/prometheus/client_python/blob/master/prometheus_client/core.py
+
+You can define custom buckets for latency, adding more buckets decreases performance but
+increases accuracy: https://prometheus.io/docs/practices/histograms/
+
+```
+PROMETHEUS_LATENCY_BUCKETS = (.1, .2, .5, .6, .8, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.5, 9.0, 12.0, 15.0, 20.0, 30.0, float("inf"))
+```
+
 ### Monitoring your databases
 
 SQLite, MySQL, and PostgreSQL databases can be monitored. Just

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ urlpatterns = [
 
 ### Configuration
 Prometheus uses Histogram based grouping for monitoring latencies. The default
-buckets are here: https://github.com/prometheus/client_python/blob/master/prometheus_client/core.py
+buckets are in middleware.py
 
 You can define custom buckets for latency, adding more buckets decreases performance but
 increases accuracy: https://prometheus.io/docs/practices/histograms/
 
+Add your latency buckets to your settings.py
 ```
 PROMETHEUS_LATENCY_BUCKETS = (.1, .2, .5, .6, .8, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.5, 9.0, 12.0, 15.0, 20.0, 30.0, float("inf"))
 ```

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -3,8 +3,10 @@ from django_prometheus.utils import Time, TimeSince, PowersOf
 import django
 from django.conf import settings
 
-DEFAULT_LATENCY_BUCKETS = (.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, float("inf"))
-LATENCY_BUCKETS = getattr(settings, "PROMETHEUS_LATENCY_BUCKETS", DEFAULT_LATENCY_BUCKETS)
+DEFAULT_LATENCY_BUCKETS = (.005, .01, .025, .05, .075, .1, .25, .5, .75,
+                           1.0, 2.5, 5.0, 7.5, 10.0, float("inf"))
+LATENCY_BUCKETS = getattr(settings, "PROMETHEUS_LATENCY_BUCKETS",
+                          DEFAULT_LATENCY_BUCKETS)
 
 if django.VERSION >= (1, 10, 0):
     from django.utils.deprecation import MiddlewareMixin

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -3,7 +3,8 @@ from django_prometheus.utils import Time, TimeSince, PowersOf
 import django
 from django.conf import settings
 
-LATENCY_BUCKETS = getattr(settings, "PROMETHEUS_LATENCY_BUCKETS", None)
+DEFAULT_LATENCY_BUCKETS = (.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, float("inf"))
+LATENCY_BUCKETS = getattr(settings, "PROMETHEUS_LATENCY_BUCKETS", DEFAULT_LATENCY_BUCKETS)
 
 if django.VERSION >= (1, 10, 0):
     from django.utils.deprecation import MiddlewareMixin
@@ -16,16 +17,10 @@ requests_total = Counter(
 responses_total = Counter(
     'django_http_responses_before_middlewares_total',
     'Total count of responses before middlewares run.')
-if LATENCY_BUCKETS is not None:
-    requests_latency_before = Histogram(
-        'django_http_requests_latency_including_middlewares_seconds',
-        ('Histogram of requests processing time (including middleware '
-         'processing time).'), buckets=LATENCY_BUCKETS)
-else:
-    requests_latency_before = Histogram(
-        'django_http_requests_latency_including_middlewares_seconds',
-        ('Histogram of requests processing time (including middleware '
-         'processing time).'))
+requests_latency_before = Histogram(
+    'django_http_requests_latency_including_middlewares_seconds',
+    ('Histogram of requests processing time (including middleware '
+     'processing time).'), buckets=LATENCY_BUCKETS)
 
 requests_unknown_latency_before = Counter(
     'django_http_requests_unknown_latency_including_middlewares_total',
@@ -49,15 +44,10 @@ class PrometheusBeforeMiddleware(MiddlewareMixin):
             requests_unknown_latency_before.inc()
         return response
 
-if LATENCY_BUCKETS is not None:
-    requests_latency_by_view_method = Histogram(
-        'django_http_requests_latency_seconds_by_view_method',
-        'Histogram of request processing time labelled by view.',
-        ['view', 'method'], buckets=LATENCY_BUCKETS)
-else:
-    requests_latency_by_view_method = Histogram(
-        'django_http_requests_latency_seconds_by_view_method',
-        'Histogram of request processing time labelled by view.', ['view', 'method'])
+requests_latency_by_view_method = Histogram(
+    'django_http_requests_latency_seconds_by_view_method',
+    'Histogram of request processing time labelled by view.',
+    ['view', 'method'], buckets=LATENCY_BUCKETS)
 
 requests_unknown_latency = Counter(
     'django_http_requests_unknown_latency_total',


### PR DESCRIPTION
Currently, the library uses the default buckets provided by the prometheus client for Histogram. Default buckets: https://github.com/prometheus/client_python/blob/master/prometheus_client/core.py

Added configuration for custom latency buckets from Settings variable.

Use cases:
- Latencies (especially above P90s) can go above 10s, and I would like to understand how much.
- Adding a granular view in smaller latencies, eg: between 2.5 - 5 seconds

I have used YAGNI to not add a complete configuration setup here. As we get more configuration, we can use patterns used by popular libraries such as RestFramework: https://github.com/encode/django-rest-framework/blob/master/rest_framework/settings.py