### PR TITLE
Fix cache version problem

### DIFF
--- a/django_prometheus/cache/backends/django_memcached_consul.py
+++ b/django_prometheus/cache/backends/django_memcached_consul.py
@@ -10,7 +10,7 @@ class MemcachedCache(memcached.MemcachedCache):
     def get(self, key, default=None, version=None):
         django_cache_get_total.labels(backend='django_memcached_consul').inc()
         cached = super(MemcachedCache, self).get(
-            key, default=None, version=None)
+            key, default=None, version=version)
         if cached is not None:
             django_cache_hits_total.labels(
                 backend='django_memcached_consul').inc()

--- a/django_prometheus/cache/backends/filebased.py
+++ b/django_prometheus/cache/backends/filebased.py
@@ -9,7 +9,7 @@ class FileBasedCache(filebased.FileBasedCache):
     def get(self, key, default=None, version=None):
         django_cache_get_total.labels(backend='filebased').inc()
         cached = super(FileBasedCache, self).get(
-            key, default=None, version=None)
+            key, default=None, version=version)
         if cached is not None:
             django_cache_hits_total.labels(backend='filebased').inc()
         else:

--- a/django_prometheus/cache/backends/locmem.py
+++ b/django_prometheus/cache/backends/locmem.py
@@ -9,7 +9,7 @@ class LocMemCache(locmem.LocMemCache):
     def get(self, key, default=None, version=None):
         django_cache_get_total.labels(backend='locmem').inc()
         cached = super(LocMemCache, self).get(
-            key, default=None, version=None)
+            key, default=None, version=version)
         if cached is not None:
             django_cache_hits_total.labels(backend='locmem').inc()
         else:

--- a/django_prometheus/cache/backends/memcached.py
+++ b/django_prometheus/cache/backends/memcached.py
@@ -9,7 +9,7 @@ class MemcachedCache(memcached.MemcachedCache):
     def get(self, key, default=None, version=None):
         django_cache_get_total.labels(backend='memcached').inc()
         cached = super(MemcachedCache, self).get(
-            key, default=None, version=None)
+            key, default=None, version=version)
         if cached is not None:
             django_cache_hits_total.labels(
                 backend='memcached').inc()

--- a/django_prometheus/tests/end2end/testapp/test_caches.py
+++ b/django_prometheus/tests/end2end/testapp/test_caches.py
@@ -30,3 +30,16 @@ class TestCachesMetrics(PrometheusTestCaseMixin, TestCase):
                 2, 'django_cache_get_hits_total', backend=supported_cache)
             self.assertMetricEquals(
                 2, 'django_cache_get_misses_total', backend=supported_cache)
+
+    def test_cache_version_support(self):
+        supported_caches = ['memcached', 'filebased', 'locmem']
+
+        # Note: those tests require a memcached server running
+        for supported_cache in supported_caches:
+            tested_cache = caches[supported_cache]
+
+            tested_cache.set('foo1', 'bar v.1', version=1)
+            tested_cache.set('foo1', 'bar v.2', version=2)
+
+            assert 'bar v.1' == tested_cache.get('foo1', version=1)
+            assert 'bar v.2' == tested_cache.get('foo1', version=2)


### PR DESCRIPTION
All cache wrapper ignore version param:
In [3]: cache.set('1', '1', version=1)

In [4]: cache.set('1', '2', version=2)

In [5]: cache.get('1', version=1)
Out[5]: '1'

In [6]: cache.get('1', version=2)
Out[6]: '1'
