### PR TITLE
Upgrade to a recent prometheus client and fix tests

### DIFF
--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -1,6 +1,5 @@
 import django
 from prometheus_client import Counter, Histogram
-from prometheus_client.utils import INF
 
 from django_prometheus.utils import Time, TimeSince, PowersOf
 
@@ -49,7 +48,7 @@ requests_latency_by_view_method = Histogram(
     buckets=(.01, .025, .05, .075,
              .1, .25, .5, .75,
              1.0, 2.5, 5.0, 7.5,
-             10.0, 25.0, 50.0, 75.0, INF))
+             10.0, 25.0, 50.0, 75.0, float("inf")))
 requests_unknown_latency = Counter(
     'django_http_requests_unknown_latency_total',
     'Count of requests for which the latency was unknown.')

--- a/django_prometheus/testutils.py
+++ b/django_prometheus/testutils.py
@@ -46,8 +46,8 @@ class PrometheusTestCaseMixin(object):
         """Gets a single metric from a frozen registry."""
         for metric in frozen_registry:
             for sample in metric.samples:
-                if sample.name == metric_name and sample.labels == labels:
-                    return sample.value
+                if sample[0] == metric_name and sample[1] == labels:
+                    return sample[2]
 
     def getMetric(self, metric_name, registry=REGISTRY, **labels):
         """Gets a single metric."""
@@ -59,8 +59,8 @@ class PrometheusTestCaseMixin(object):
         output = []
         for metric in frozen_registry:
             for sample in metric.samples:
-                if sample.name == metric_name:
-                    output.append((sample.labels, sample.value))
+                if sample[0] == metric_name:
+                    output.append((sample[1], sample[2]))
         return output
 
     def getMetricVector(self, metric_name, registry=REGISTRY):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.8
 django-redis>=4.8
 pep8>=1.6.2
-prometheus-client>=0.0.21,<0.4.0
+prometheus-client>=0.0.21
 pip-prometheus>=1.1.0
 mock>=1.0.1
 mysqlclient<1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.8
 django-redis>=4.8
 pep8>=1.6.2
-prometheus-client>=0.0.21
+prometheus-client>=0.7
 pip-prometheus>=1.1.0
 mock>=1.0.1
 mysqlclient<1.4


### PR DESCRIPTION
I've been way out of touch with this project, and I've seriously neglected its maintenance. I don't have a need for prometheus_client in my day job or elsewhere so it's hard for me to keep up with what the issues are. Still, there has been strong interest in keeping this working so I'd like to at least have passing tests and to be able to release the recent merges.

With the recently merged PRs (#103, #100) the tests still didn't pass. I've decided to just move forward with requiring a recent prometheus_client, because supporting super old APIs is a pain. Before I merge, I'd like to sollicit feedback from people who have been helping with the maintenance - @asherf @stealthybox @paweldudzinski @bz1 do you think it's acceptable to depend on the latest prometheus_client? Please object if not.