### PR TITLE
match install_requires to requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     test_suite="django_prometheus.tests",
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        "prometheus_client>=0.0.21,<0.4.0",
+        "prometheus-client>=0.7",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Based on top of https://github.com/korfuri/django-prometheus/pull/105
fixes a mismatch in required Prometheus client version