### PR TITLE
Change config.file declaration from .conf to .yml

### DIFF
--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -11,7 +11,7 @@ To run a demo Prometheus, you'll need to follow these steps:
 * Run prometheus like this:
   ```shell
   ~/prometheus/prometheus \
-    --config.file=prometheus.conf \
+    --config.file=prometheus.yml \
     --web.console.templates consoles/ \
     --web.console.libraries ~/prometheus/console_libraries/
   ```


### PR DESCRIPTION
In the example the command given asks you to use prometheus.conf for your config.file, however, this file doesn't exist in the example. To keep consistent I've changed this.