### PR TITLE
Use range instead of xrange for Python 3 compatibility

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -64,7 +64,7 @@ def SetupPrometheusEndpointOnPortRange(port_range, addr=''):
     to aggregate across workers.
 
     port_range may be any iterable object that contains a list of
-    ports. Typically this would be an xrange of contiguous ports.
+    ports. Typically this would be a `range` of contiguous ports.
 
     As soon as one port is found that can serve, use this one and stop
     trying.

--- a/documentation/exports.md
+++ b/documentation/exports.md
@@ -66,7 +66,7 @@ time, and exporting on a single port doesn't work.
 The following settings can be used instead:
 
 ```python
-PROMETHEUS_METRICS_EXPORT_PORT_RANGE = xrange(8001, 8050)
+PROMETHEUS_METRICS_EXPORT_PORT_RANGE = range(8001, 8050)
 ```
 
 This will make Django-Prometheus try to export /metrics on port


### PR DESCRIPTION
`xrange` does not exist in Python 3 and Python 2 EOL is near