### PR TITLE
Return the port chosen from port range in export setup

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -69,9 +69,11 @@ def SetupPrometheusEndpointOnPortRange(port_range, addr=''):
     As soon as one port is found that can serve, use this one and stop
     trying.
 
+    Returns the port chosen (an `int`), or `None` if no port in the
+    supplied range was available.
+
     The same caveats regarding autoreload apply. Do not use this when
     Django's autoreloader is active.
-
     """
     assert os.environ.get('RUN_MAIN') != 'true', (
         'The thread-based exporter can\'t be safely used when django\'s '
@@ -88,7 +90,10 @@ def SetupPrometheusEndpointOnPortRange(port_range, addr=''):
         thread.daemon = True
         thread.start()
         logger.info('Exporting Prometheus /metrics/ on port %s' % port)
-        return  # Stop trying ports at this point
+        return port  # Stop trying ports at this point
+    logger.info('Cannot export Prometheus /metrics/ - '
+                'no available ports in supplied range')
+    return None
 
 
 def SetupPrometheusExportsFromConfig():

--- a/django_prometheus/tests/test_exports.py
+++ b/django_prometheus/tests/test_exports.py
@@ -9,16 +9,32 @@ from mock import patch, call, ANY, MagicMock
 
 class ExportTest(unittest.TestCase):
     @patch('django_prometheus.exports.HTTPServer')
-    def testPortRange(self, httpserver_mock):
+    def testPortRangeAvailable(self, httpserver_mock):
+        """Test port range setup with an available port."""
         httpserver_mock.side_effect = [socket.error, MagicMock()]
         port_range = [8000, 8001]
-        SetupPrometheusEndpointOnPortRange(port_range)
+        port_chosen = SetupPrometheusEndpointOnPortRange(port_range)
 
         expected_calls = [
             call(('', 8000), ANY),
             call(('', 8001), ANY),
         ]
         self.assertEqual(httpserver_mock.mock_calls, expected_calls)
+        self.assertEqual(port_chosen, 8001)
+
+    @patch('django_prometheus.exports.HTTPServer')
+    def testPortRangeUnavailable(self, httpserver_mock):
+        """Test port range setup with no available ports."""
+        httpserver_mock.side_effect = [socket.error, socket.error]
+        port_range = [8000, 8001]
+        port_chosen = SetupPrometheusEndpointOnPortRange(port_range)
+
+        expected_calls = [
+            call(('', 8000), ANY),
+            call(('', 8001), ANY),
+        ]
+        self.assertEqual(httpserver_mock.mock_calls, expected_calls)
+        self.assertIsNone(port_chosen)
 
 
 if __name__ == 'main':


### PR DESCRIPTION
I currently use a copypasta version of `SetupPrometheusEndpointOnPortRange()` that returns the port that was actually chosen from the range when starting the thread-based exporter. This is necessary because I need to dynamically register the exporter with a Consul agent for discovery of the Prometheus metrics endpoint for scraping.

This PR just returns the chosen port (`int`), or if no ports are available, explicitly returns `None`.

Added a test for the case where no ports are available, modified the existing test for the case where a port is available.