### PR TITLE
Add postgis support (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ services:
   - redis
   - mysql
   - postgresql
+addons:
+  postgresql: 9.5
+  apt:
+    packages:
+      - postgresql-9.5-postgis-2.2
+      - gdal-bin
 matrix:
   exclude:
     - python: "2.7"
@@ -32,6 +38,8 @@ install:
   - pip install -r requirements.txt
   - pip install -q Django==$DJANGO_VERSION
   - mysql -e 'create database django_prometheus_1;'
+  - psql -U postgres -c "create database postgis"
+  - psql -U postgres postgis -c "ALTER EXTENSION postgis UPDATE;"
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == "3.7" ]]; then black --check django_prometheus/; fi
   - python setup.py test

--- a/django_prometheus/db/backends/postgis/base.py
+++ b/django_prometheus/db/backends/postgis/base.py
@@ -1,0 +1,24 @@
+import psycopg2.extensions
+from django.contrib.gis.db.backends.postgis import base
+
+from django_prometheus.db.common import DatabaseWrapperMixin, ExportingCursorWrapper
+
+
+class DatabaseFeatures(base.DatabaseFeatures):
+    """Our database has the exact same features as the base one."""
+
+    pass
+
+
+class DatabaseWrapper(DatabaseWrapperMixin, base.DatabaseWrapper):
+    def get_connection_params(self):
+        conn_params = super(DatabaseWrapper, self).get_connection_params()
+        conn_params["cursor_factory"] = ExportingCursorWrapper(
+            psycopg2.extensions.cursor, self.alias, self.vendor
+        )
+        return conn_params
+
+    def create_cursor(self, name=None):
+        # cursor_factory is a kwarg to connect() so restore create_cursor()'s
+        # default behavior
+        return base.DatabaseWrapper.create_cursor(self, name=name)

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -107,6 +107,15 @@ DATABASES = {
         "HOST": "localhost",
         "PORT": "5432",
     },
+    # Comment this to not test django_prometheus.db.backends.postgis.
+    "postgis": {
+        "ENGINE": "django_prometheus.db.backends.postgis",
+        "NAME": "postgis",
+        "USER": "postgres",
+        "PASSWORD": "",
+        "HOST": "localhost",
+        "PORT": "5432",
+    },
     # Comment this to not test django_prometheus.db.backends.mysql.
     "mysql": {
         "ENGINE": "django_prometheus.db.backends.mysql",

--- a/django_prometheus/tests/end2end/testapp/test_db.py
+++ b/django_prometheus/tests/end2end/testapp/test_db.py
@@ -104,6 +104,35 @@ class TestPostgresDbMetrics(BaseDbMetricTest):
         )
 
 
+@skipUnless(
+    "postgis" in connections, "Skipped unless postgis database is enabled"
+)
+class TestPostgisDbMetrics(BaseDbMetricTest):
+    """Test django_prometheus.db metrics for postgis backend.
+
+    Note regarding the values of metrics: many tests interact with the
+    database, and the test runner itself does. As such, tests that
+    require that a metric has a specific value are at best very
+    fragile. Consider asserting that the value exceeds a certain
+    threshold, or check by how much it increased during the test.
+    """
+
+    def testCounters(self):
+        r = self.saveRegistry()
+        cursor = connections["postgis"].cursor()
+
+        for _ in range(20):
+            cursor.execute("SELECT 1")
+
+        self.assertMetricCompare(
+            r,
+            lambda a, b: a + 20 <= b < a + 25,
+            "django_db_execute_total",
+            alias="postgis",
+            vendor="postgis",
+        )
+
+
 @skipUnless("mysql" in connections, "Skipped unless mysql database is enabled")
 class TestMysDbMetrics(BaseDbMetricTest):
     """Test django_prometheus.db metrics for mys backend.


### PR DESCRIPTION
since I can't add to #41 I created a new PR here. 

@korfuri I did try to add the tests. However even after some fiddling I'm not sure how to successfully run all the tests/, e.g. I tried modifying `settings.py` and ran `python django_prometheus/tests/end2end/manage.py test -v 3` and `python django_prometheus/tests/end2end/manage.py test -v 3  test_db`  but I don't think the correct tests are running, neither am I sure if I'm doing it correctly at all. Please advise :)

*Off-topic*: Because I run everything with `poetry` these days I created a `pyproject.toml` - would you be interested in such a PR as well? It will replace `requirements.txt, setup.py, setup.cfg and MANIFEST.in` and it's getting some major traction now anywyays.