### PR TITLE
feat: add support for django-redis-cache

### DIFF
--- a/django_prometheus/cache/backends/redis2.py
+++ b/django_prometheus/cache/backends/redis2.py
@@ -1,0 +1,28 @@
+from django_prometheus.cache.metrics import (
+    django_cache_get_fail_total,
+    django_cache_get_total,
+    django_cache_hits_total,
+    django_cache_misses_total,
+)
+from redis_cache.backends.single import RedisCache as SingleRedisCache
+
+_REDIS2_BACKEND = "redis_2"
+
+
+class RedisCache(SingleRedisCache):
+    """Inherit redis to add metrics about hit/miss/interruption ratio."""
+
+    def get(self, key, default=None):
+        django_cache_get_total.labels(backend=_REDIS2_BACKEND).inc()
+
+        try:
+            cached = super(RedisCache, self).get(key, default=None)
+            if cached is not None:
+                django_cache_hits_total.labels(backend=_REDIS2_BACKEND).inc()
+                return cached
+
+            django_cache_misses_total.labels(backend=_REDIS2_BACKEND).inc()
+            return default
+        except Exception:
+            django_cache_get_fail_total.labels(backend=_REDIS2_BACKEND).inc()
+            raise

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -116,6 +116,16 @@ CACHES = {
         "LOCATION": "redis://127.0.0.1:6666/1",
         "OPTIONS": {"IGNORE_EXCEPTIONS": True},
     },
+    # Redis 2
+    "redis_2": {
+        "BACKEND": "django_prometheus.cache.backends.redis2.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/2",
+    },
+    # Fake redis config emulated stopped service
+    "stopped_redis_2": {
+        "BACKEND": "django_prometheus.cache.backends.redis2.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6666/2",
+    },
 }
 
 # Internationalization

--- a/django_prometheus/tests/end2end/testapp/test_caches.py
+++ b/django_prometheus/tests/end2end/testapp/test_caches.py
@@ -3,104 +3,50 @@ from django.test import TestCase
 from django_prometheus.testutils import PrometheusTestCaseMixin
 from redis import RedisError
 
+_TOTAL = "django_cache_get_total"
+_HIT = "django_cache_get_hits_total"
+_MISS = "django_cache_get_misses_total"
+_FAIL = "django_cache_get_fail_total"
+
+_REDIS = "redis"
+_REDIS2 = "redis_2"
+
+_ALL_CACHES = ["memcached", "filebased", "locmem", _REDIS, _REDIS2]
+_VERSIONED_CACHES = ["memcached", "filebased", "locmem", _REDIS]
+
 
 class TestCachesMetrics(PrometheusTestCaseMixin, TestCase):
     """Test django_prometheus.caches metrics."""
 
     def testCounters(self):
-        supported_caches = ["memcached", "filebased", "locmem", "redis"]
 
         # Note: those tests require a memcached server running
-        for supported_cache in supported_caches:
+        for supported_cache in _ALL_CACHES:
             tested_cache = caches[supported_cache]
-
-            total_before = (
-                self.getMetric("django_cache_get_total", backend=supported_cache) or 0
-            )
-            hit_before = (
-                self.getMetric("django_cache_get_hits_total", backend=supported_cache)
-                or 0
-            )
-            miss_before = (
-                self.getMetric("django_cache_get_misses_total", backend=supported_cache)
-                or 0
-            )
-
             tested_cache.set("foo1", "bar")
-            tested_cache.get("foo1")
-            tested_cache.get("foo1")
-            tested_cache.get("foofoo")
 
-            result = tested_cache.get("foofoo", default="default")
+            # initial counters
+            total_before = self.getMetric(_TOTAL, backend=supported_cache)
+            hit_before = self.getMetric(_HIT, backend=supported_cache)
+            miss_before = self.getMetric(_MISS, backend=supported_cache)
 
-            assert result == "default"
+            self.assertEqual(tested_cache.get("foo1"), "bar")
+            self.assertEqual(tested_cache.get("foo1"), "bar")
+            self.assertIsNone(tested_cache.get("foo2"))
+            self.assertEqual(tested_cache.get("foo2", default="default"), "default")
 
             self.assertMetricEquals(
-                total_before + 4, "django_cache_get_total", backend=supported_cache
+                (total_before or 0) + 4, _TOTAL, backend=supported_cache
             )
             self.assertMetricEquals(
-                hit_before + 2, "django_cache_get_hits_total", backend=supported_cache
+                (hit_before or 0) + 2, _HIT, backend=supported_cache
             )
             self.assertMetricEquals(
-                miss_before + 2,
-                "django_cache_get_misses_total",
-                backend=supported_cache,
+                (miss_before or 0) + 2, _MISS, backend=supported_cache
             )
-
-    def test_redis_cache_fail(self):
-
-        # Note: test use fake service config (like if server was stopped)
-        supported_cache = "redis"
-
-        total_before = (
-            self.getMetric("django_cache_get_total", backend=supported_cache) or 0
-        )
-        fail_before = (
-            self.getMetric("django_cache_get_fail_total", backend=supported_cache) or 0
-        )
-        hit_before = (
-            self.getMetric("django_cache_get_hits_total", backend=supported_cache) or 0
-        )
-        miss_before = (
-            self.getMetric("django_cache_get_misses_total", backend=supported_cache)
-            or 0
-        )
-
-        tested_cache = caches["stopped_redis_ignore_exception"]
-        tested_cache.get("foo1")
-
-        self.assertMetricEquals(
-            hit_before, "django_cache_get_hits_total", backend=supported_cache
-        )
-        self.assertMetricEquals(
-            miss_before, "django_cache_get_misses_total", backend=supported_cache
-        )
-        self.assertMetricEquals(
-            total_before + 1, "django_cache_get_total", backend=supported_cache
-        )
-        self.assertMetricEquals(
-            fail_before + 1, "django_cache_get_fail_total", backend=supported_cache
-        )
-
-        tested_cache = caches["stopped_redis"]
-        with self.assertRaises(RedisError):
-            tested_cache.get("foo1")
-
-        self.assertMetricEquals(
-            hit_before, "django_cache_get_hits_total", backend=supported_cache
-        )
-        self.assertMetricEquals(
-            miss_before, "django_cache_get_misses_total", backend=supported_cache
-        )
-        self.assertMetricEquals(
-            total_before + 2, "django_cache_get_total", backend=supported_cache
-        )
-        self.assertMetricEquals(
-            fail_before + 2, "django_cache_get_fail_total", backend=supported_cache
-        )
 
     def test_cache_version_support(self):
-        supported_caches = ["memcached", "filebased", "locmem", "redis"]
+        supported_caches = _VERSIONED_CACHES
 
         # Note: those tests require a memcached server running
         for supported_cache in supported_caches:
@@ -109,5 +55,57 @@ class TestCachesMetrics(PrometheusTestCaseMixin, TestCase):
             tested_cache.set("foo1", "bar v.1", version=1)
             tested_cache.set("foo1", "bar v.2", version=2)
 
-            assert "bar v.1" == tested_cache.get("foo1", version=1)
-            assert "bar v.2" == tested_cache.get("foo1", version=2)
+            self.assertEqual(tested_cache.get("foo1", version=1), "bar v.1")
+            self.assertEqual(tested_cache.get("foo1", version=2), "bar v.2")
+
+    def test_redis_cache_fail(self):
+
+        # Note: test use fake service config (like if server was stopped)
+        supported_cache = _REDIS
+
+        total_before = self.getMetric(_TOTAL, backend=supported_cache)
+        fail_before = self.getMetric(_FAIL, backend=supported_cache)
+        hit_before = self.getMetric(_HIT, backend=supported_cache)
+        miss_before = self.getMetric(_MISS, backend=supported_cache)
+
+        tested_cache = caches["stopped_redis_ignore_exception"]
+        tested_cache.get("foo1")
+
+        self.assertMetricEquals(
+            (total_before or 0) + 1, _TOTAL, backend=supported_cache
+        )
+        self.assertMetricEquals((fail_before or 0) + 1, _FAIL, backend=supported_cache)
+        self.assertMetricEquals(hit_before, _HIT, backend=supported_cache)
+        self.assertMetricEquals(miss_before, _MISS, backend=supported_cache)
+
+        tested_cache = caches["stopped_redis"]
+        with self.assertRaises(RedisError):
+            tested_cache.get("foo1")
+
+        self.assertMetricEquals(
+            (total_before or 0) + 2, _TOTAL, backend=supported_cache
+        )
+        self.assertMetricEquals((fail_before or 0) + 2, _FAIL, backend=supported_cache)
+        self.assertMetricEquals(hit_before, _HIT, backend=supported_cache)
+        self.assertMetricEquals(miss_before, _MISS, backend=supported_cache)
+
+    def test_redis2_cache_fail(self):
+
+        # Note: test use fake service config (like if server was stopped)
+        supported_cache = _REDIS2
+        tested_cache = caches["stopped_redis_2"]
+
+        total_before = self.getMetric(_TOTAL, backend=supported_cache)
+        fail_before = self.getMetric(_FAIL, backend=supported_cache)
+        hit_before = self.getMetric(_HIT, backend=supported_cache)
+        miss_before = self.getMetric(_MISS, backend=supported_cache)
+
+        with self.assertRaises(RedisError):
+            tested_cache.get("foo1")
+
+        self.assertMetricEquals(
+            (total_before or 0) + 1, _TOTAL, backend=supported_cache
+        )
+        self.assertMetricEquals((fail_before or 0) + 1, _FAIL, backend=supported_cache)
+        self.assertMetricEquals(hit_before, _HIT, backend=supported_cache)
+        self.assertMetricEquals(miss_before, _MISS, backend=supported_cache)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+django-redis-cache
 django-redis>=4.8
 black; python_version >= '3.6'
 flake8

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,18 @@ deps =
     -rrequirements.txt
 skip_missing_interpreters=true
 
-changedir = 
+changedir =
     end2end: {toxinidir}/django_prometheus/tests/end2end
 setenv =
     end2end: PYTHONPATH = {toxinidir}
-    end2end: DJANGO_SETTINGS_MODULE=testapp.settings 
+    end2end: DJANGO_SETTINGS_MODULE=testapp.settings
 commands =
     end2end: coverage run --source=django_prometheus -m pytest testapp/
     unittests: coverage run --source=django_prometheus setup.py test
     unittests: python setup.py sdist bdist_wheel
 
 [testenv:py37-lint]
-deps = 
+deps =
     black
     flake8
     isort


### PR DESCRIPTION
It looks like that `django_redis` is not longer maintained (the last release was on 19th Oct 2018 https://github.com/niwinz/django-redis/releases/tag/4.10.0)

So I added support for [django-redis-cache](https://github.com/sebleier/django-redis-cache)
