### PR TITLE
configurable metric namespace

### DIFF
--- a/django_prometheus/cache/metrics.py
+++ b/django_prometheus/cache/metrics.py
@@ -1,14 +1,20 @@
 from prometheus_client import Counter
 
+from django_prometheus.conf import NAMESPACE
+
 django_cache_get_total = Counter(
-    "django_cache_get_total", "Total get requests on cache", ["backend"]
+    "django_cache_get_total", "Total get requests on cache", ["backend"],
+    namespace=NAMESPACE
 )
 django_cache_hits_total = Counter(
-    "django_cache_get_hits_total", "Total hits on cache", ["backend"]
+    "django_cache_get_hits_total", "Total hits on cache", ["backend"],
+    namespace=NAMESPACE
 )
 django_cache_misses_total = Counter(
-    "django_cache_get_misses_total", "Total misses on cache", ["backend"]
+    "django_cache_get_misses_total", "Total misses on cache", ["backend"],
+    namespace=NAMESPACE
 )
 django_cache_get_fail_total = Counter(
-    "django_cache_get_fail_total", "Total get request failures by cache", ["backend"]
+    "django_cache_get_fail_total", "Total get request failures by cache", ["backend"],
+    namespace=NAMESPACE
 )

--- a/django_prometheus/cache/metrics.py
+++ b/django_prometheus/cache/metrics.py
@@ -3,18 +3,26 @@ from prometheus_client import Counter
 from django_prometheus.conf import NAMESPACE
 
 django_cache_get_total = Counter(
-    "django_cache_get_total", "Total get requests on cache", ["backend"],
-    namespace=NAMESPACE
+    "django_cache_get_total",
+    "Total get requests on cache",
+    ["backend"],
+    namespace=NAMESPACE,
 )
 django_cache_hits_total = Counter(
-    "django_cache_get_hits_total", "Total hits on cache", ["backend"],
-    namespace=NAMESPACE
+    "django_cache_get_hits_total",
+    "Total hits on cache",
+    ["backend"],
+    namespace=NAMESPACE,
 )
 django_cache_misses_total = Counter(
-    "django_cache_get_misses_total", "Total misses on cache", ["backend"],
-    namespace=NAMESPACE
+    "django_cache_get_misses_total",
+    "Total misses on cache",
+    ["backend"],
+    namespace=NAMESPACE,
 )
 django_cache_get_fail_total = Counter(
-    "django_cache_get_fail_total", "Total get request failures by cache", ["backend"],
-    namespace=NAMESPACE
+    "django_cache_get_fail_total",
+    "Total get request failures by cache",
+    ["backend"],
+    namespace=NAMESPACE,
 )

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+
+NAMESPACE = getattr(settings, 'PROMETHEUS_METRIC_NAMESPACE', '')

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -1,5 +1,3 @@
-import os
-
 from django.conf import settings
 
 NAMESPACE = ""

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -1,4 +1,5 @@
 import os
+
 from django.conf import settings
 
 NAMESPACE = ""

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -6,5 +6,3 @@ NAMESPACE = ""
 
 if settings.configured:
     NAMESPACE = getattr(settings, "PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)
-
-NAMESPACE = os.getenv("PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -5,9 +5,6 @@ from django.conf import settings
 NAMESPACE = ""
 
 if settings.configured:
-    try:
-        NAMESPACE = settings.PROMETHEUS_METRIC_NAMESPACE
-    except AttributeError:
-        pass
+    NAMESPACE = getattr(settings, "PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)
 
 NAMESPACE = os.getenv("PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -1,6 +1,12 @@
+import os
 from django.conf import settings
 
-if not settings.configured:
-    settings.configure()
+NAMESPACE = ""
 
-NAMESPACE = getattr(settings, "PROMETHEUS_METRIC_NAMESPACE", "")
+if settings.configured:
+    try:
+        NAMESPACE = settings.PROMETHEUS_METRIC_NAMESPACE
+    except AttributeError:
+        pass
+
+NAMESPACE = os.getenv("PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -3,4 +3,4 @@ from django.conf import settings
 if not settings.configured:
     settings.configure()
 
-NAMESPACE = getattr(settings, 'PROMETHEUS_METRIC_NAMESPACE', '')
+NAMESPACE = getattr(settings, "PROMETHEUS_METRIC_NAMESPACE", "")

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -1,4 +1,6 @@
 from django.conf import settings
 
+if not settings.configured:
+    settings.configure()
 
 NAMESPACE = getattr(settings, 'PROMETHEUS_METRIC_NAMESPACE', '')

--- a/django_prometheus/db/metrics.py
+++ b/django_prometheus/db/metrics.py
@@ -6,14 +6,14 @@ connections_total = Counter(
     "django_db_new_connections_total",
     "Counter of created connections by database and by vendor.",
     ["alias", "vendor"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )
 
 connection_errors_total = Counter(
     "django_db_new_connection_errors_total",
     "Counter of connection failures by database and by vendor.",
     ["alias", "vendor"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )
 
 execute_total = Counter(
@@ -23,7 +23,7 @@ execute_total = Counter(
         " bulk executions."
     ),
     ["alias", "vendor"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )
 
 
@@ -31,7 +31,7 @@ execute_many_total = Counter(
     "django_db_execute_many_total",
     ("Counter of executed statements in bulk operations by database and" " by vendor."),
     ["alias", "vendor"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )
 
 
@@ -39,5 +39,5 @@ errors_total = Counter(
     "django_db_errors_total",
     ("Counter of execution errors by database, vendor and exception type."),
     ["alias", "vendor", "type"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )

--- a/django_prometheus/db/metrics.py
+++ b/django_prometheus/db/metrics.py
@@ -1,15 +1,19 @@
 from prometheus_client import Counter
 
+from django_prometheus.conf import NAMESPACE
+
 connections_total = Counter(
     "django_db_new_connections_total",
     "Counter of created connections by database and by vendor.",
     ["alias", "vendor"],
+    namespace=NAMESPACE
 )
 
 connection_errors_total = Counter(
     "django_db_new_connection_errors_total",
     "Counter of connection failures by database and by vendor.",
     ["alias", "vendor"],
+    namespace=NAMESPACE
 )
 
 execute_total = Counter(
@@ -19,6 +23,7 @@ execute_total = Counter(
         " bulk executions."
     ),
     ["alias", "vendor"],
+    namespace=NAMESPACE
 )
 
 
@@ -26,6 +31,7 @@ execute_many_total = Counter(
     "django_db_execute_many_total",
     ("Counter of executed statements in bulk operations by database and" " by vendor."),
     ["alias", "vendor"],
+    namespace=NAMESPACE
 )
 
 
@@ -33,4 +39,5 @@ errors_total = Counter(
     "django_db_errors_total",
     ("Counter of execution errors by database, vendor and exception type."),
     ["alias", "vendor", "type"],
+    namespace=NAMESPACE
 )

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from django_prometheus.utils import PowersOf, Time, TimeSince
 
+from django_prometheus.conf import NAMESPACE
+
 DEFAULT_LATENCY_BUCKETS = (
     0.01,
     0.025,
@@ -47,11 +49,13 @@ class Metrics(object):
             Counter,
             "django_http_requests_before_middlewares_total",
             "Total count of requests before middlewares run.",
+            namespace=NAMESPACE
         )
         self.responses_total = self.register_metric(
             Counter,
             "django_http_responses_before_middlewares_total",
             "Total count of responses before middlewares run.",
+            namespace=NAMESPACE
         )
         self.requests_latency_before = self.register_metric(
             Histogram,
@@ -60,6 +64,7 @@ class Metrics(object):
                 "Histogram of requests processing time (including middleware "
                 "processing time)."
             ),
+            namespace=NAMESPACE
         )
         self.requests_unknown_latency_before = self.register_metric(
             Counter,
@@ -68,6 +73,7 @@ class Metrics(object):
                 "Count of requests for which the latency was unknown (when computing "
                 "django_http_requests_latency_including_middlewares_seconds)."
             ),
+            namespace=NAMESPACE
         )
         self.requests_latency_by_view_method = self.register_metric(
             Histogram,
@@ -77,27 +83,32 @@ class Metrics(object):
             buckets=getattr(
                 settings, "PROMETHEUS_LATENCY_BUCKETS", DEFAULT_LATENCY_BUCKETS
             ),
+            namespace=NAMESPACE
         )
         self.requests_unknown_latency = self.register_metric(
             Counter,
             "django_http_requests_unknown_latency_total",
             "Count of requests for which the latency was unknown.",
+            namespace=NAMESPACE
         )
         # Set in process_request
         self.requests_ajax = self.register_metric(
-            Counter, "django_http_ajax_requests_total", "Count of AJAX requests."
+            Counter, "django_http_ajax_requests_total", "Count of AJAX requests.",
+            namespace=NAMESPACE
         )
         self.requests_by_method = self.register_metric(
             Counter,
             "django_http_requests_total_by_method",
             "Count of requests by method.",
             ["method"],
+            namespace=NAMESPACE
         )
         self.requests_by_transport = self.register_metric(
             Counter,
             "django_http_requests_total_by_transport",
             "Count of requests by transport.",
             ["transport"],
+            namespace=NAMESPACE
         )
         # Set in process_view
         self.requests_by_view_transport_method = self.register_metric(
@@ -105,12 +116,14 @@ class Metrics(object):
             "django_http_requests_total_by_view_transport_method",
             "Count of requests by view, transport, method.",
             ["view", "transport", "method"],
+            namespace=NAMESPACE
         )
         self.requests_body_bytes = self.register_metric(
             Histogram,
             "django_http_requests_body_total_bytes",
             "Histogram of requests by body size.",
             buckets=PowersOf(2, 30),
+            namespace=NAMESPACE
         )
         # Set in process_template_response
         self.responses_by_templatename = self.register_metric(
@@ -118,6 +131,7 @@ class Metrics(object):
             "django_http_responses_total_by_templatename",
             "Count of responses by template name.",
             ["templatename"],
+            namespace=NAMESPACE
         )
         # Set in process_response
         self.responses_by_status = self.register_metric(
@@ -125,29 +139,34 @@ class Metrics(object):
             "django_http_responses_total_by_status",
             "Count of responses by status.",
             ["status"],
+            namespace=NAMESPACE
         )
         self.responses_by_status_view_method = self.register_metric(
             Counter,
             "django_http_responses_total_by_status_view_method",
             "Count of responses by status, view, method.",
             ["status", "view", "method"],
+            namespace=NAMESPACE
         )
         self.responses_body_bytes = self.register_metric(
             Histogram,
             "django_http_responses_body_total_bytes",
             "Histogram of responses by body size.",
             buckets=PowersOf(2, 30),
+            namespace=NAMESPACE
         )
         self.responses_by_charset = self.register_metric(
             Counter,
             "django_http_responses_total_by_charset",
             "Count of responses by charset.",
             ["charset"],
+            namespace=NAMESPACE
         )
         self.responses_streaming = self.register_metric(
             Counter,
             "django_http_responses_streaming_total",
             "Count of streaming responses.",
+            namespace=NAMESPACE
         )
         # Set in process_exception
         self.exceptions_by_type = self.register_metric(
@@ -155,12 +174,14 @@ class Metrics(object):
             "django_http_exceptions_total_by_type",
             "Count of exceptions by object type.",
             ["type"],
+            namespace=NAMESPACE
         )
         self.exceptions_by_view = self.register_metric(
             Counter,
             "django_http_exceptions_total_by_view",
             "Count of exceptions by view.",
             ["view"],
+            namespace=NAMESPACE
         )
 
 

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -2,9 +2,8 @@ from prometheus_client import Counter, Histogram
 
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
-from django_prometheus.utils import PowersOf, Time, TimeSince
-
 from django_prometheus.conf import NAMESPACE
+from django_prometheus.utils import PowersOf, Time, TimeSince
 
 DEFAULT_LATENCY_BUCKETS = (
     0.01,
@@ -49,13 +48,13 @@ class Metrics(object):
             Counter,
             "django_http_requests_before_middlewares_total",
             "Total count of requests before middlewares run.",
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.responses_total = self.register_metric(
             Counter,
             "django_http_responses_before_middlewares_total",
             "Total count of responses before middlewares run.",
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.requests_latency_before = self.register_metric(
             Histogram,
@@ -64,7 +63,7 @@ class Metrics(object):
                 "Histogram of requests processing time (including middleware "
                 "processing time)."
             ),
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.requests_unknown_latency_before = self.register_metric(
             Counter,
@@ -73,7 +72,7 @@ class Metrics(object):
                 "Count of requests for which the latency was unknown (when computing "
                 "django_http_requests_latency_including_middlewares_seconds)."
             ),
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.requests_latency_by_view_method = self.register_metric(
             Histogram,
@@ -83,32 +82,34 @@ class Metrics(object):
             buckets=getattr(
                 settings, "PROMETHEUS_LATENCY_BUCKETS", DEFAULT_LATENCY_BUCKETS
             ),
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.requests_unknown_latency = self.register_metric(
             Counter,
             "django_http_requests_unknown_latency_total",
             "Count of requests for which the latency was unknown.",
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         # Set in process_request
         self.requests_ajax = self.register_metric(
-            Counter, "django_http_ajax_requests_total", "Count of AJAX requests.",
-            namespace=NAMESPACE
+            Counter,
+            "django_http_ajax_requests_total",
+            "Count of AJAX requests.",
+            namespace=NAMESPACE,
         )
         self.requests_by_method = self.register_metric(
             Counter,
             "django_http_requests_total_by_method",
             "Count of requests by method.",
             ["method"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.requests_by_transport = self.register_metric(
             Counter,
             "django_http_requests_total_by_transport",
             "Count of requests by transport.",
             ["transport"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         # Set in process_view
         self.requests_by_view_transport_method = self.register_metric(
@@ -116,14 +117,14 @@ class Metrics(object):
             "django_http_requests_total_by_view_transport_method",
             "Count of requests by view, transport, method.",
             ["view", "transport", "method"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.requests_body_bytes = self.register_metric(
             Histogram,
             "django_http_requests_body_total_bytes",
             "Histogram of requests by body size.",
             buckets=PowersOf(2, 30),
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         # Set in process_template_response
         self.responses_by_templatename = self.register_metric(
@@ -131,7 +132,7 @@ class Metrics(object):
             "django_http_responses_total_by_templatename",
             "Count of responses by template name.",
             ["templatename"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         # Set in process_response
         self.responses_by_status = self.register_metric(
@@ -139,34 +140,34 @@ class Metrics(object):
             "django_http_responses_total_by_status",
             "Count of responses by status.",
             ["status"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.responses_by_status_view_method = self.register_metric(
             Counter,
             "django_http_responses_total_by_status_view_method",
             "Count of responses by status, view, method.",
             ["status", "view", "method"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.responses_body_bytes = self.register_metric(
             Histogram,
             "django_http_responses_body_total_bytes",
             "Histogram of responses by body size.",
             buckets=PowersOf(2, 30),
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.responses_by_charset = self.register_metric(
             Counter,
             "django_http_responses_total_by_charset",
             "Count of responses by charset.",
             ["charset"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.responses_streaming = self.register_metric(
             Counter,
             "django_http_responses_streaming_total",
             "Count of streaming responses.",
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         # Set in process_exception
         self.exceptions_by_type = self.register_metric(
@@ -174,14 +175,14 @@ class Metrics(object):
             "django_http_exceptions_total_by_type",
             "Count of exceptions by object type.",
             ["type"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
         self.exceptions_by_view = self.register_metric(
             Counter,
             "django_http_exceptions_total_by_view",
             "Count of exceptions by view.",
             ["view"],
-            namespace=NAMESPACE
+            namespace=NAMESPACE,
         )
 
 

--- a/django_prometheus/migrations.py
+++ b/django_prometheus/migrations.py
@@ -2,21 +2,20 @@ from prometheus_client import Gauge
 
 from django.db import connections
 from django.db.backends.dummy.base import DatabaseWrapper
-
 from django_prometheus.conf import NAMESPACE
 
 unapplied_migrations = Gauge(
     "django_migrations_unapplied_total",
     "Count of unapplied migrations by database connection",
     ["connection"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )
 
 applied_migrations = Gauge(
     "django_migrations_applied_total",
     "Count of applied migrations by database connection",
     ["connection"],
-    namespace=NAMESPACE
+    namespace=NAMESPACE,
 )
 
 

--- a/django_prometheus/migrations.py
+++ b/django_prometheus/migrations.py
@@ -3,16 +3,20 @@ from prometheus_client import Gauge
 from django.db import connections
 from django.db.backends.dummy.base import DatabaseWrapper
 
+from django_prometheus.conf import NAMESPACE
+
 unapplied_migrations = Gauge(
     "django_migrations_unapplied_total",
     "Count of unapplied migrations by database connection",
     ["connection"],
+    namespace=NAMESPACE
 )
 
 applied_migrations = Gauge(
     "django_migrations_applied_total",
     "Count of applied migrations by database connection",
     ["connection"],
+    namespace=NAMESPACE
 )
 
 

--- a/django_prometheus/models.py
+++ b/django_prometheus/models.py
@@ -1,15 +1,20 @@
 from prometheus_client import Counter
 
+from django_prometheus.conf import NAMESPACE
+
 model_inserts = Counter(
-    "django_model_inserts_total", "Number of insert operations by model.", ["model"]
+    "django_model_inserts_total", "Number of insert operations by model.", ["model"],
+    namespace=NAMESPACE
 )
 
 model_updates = Counter(
-    "django_model_updates_total", "Number of update operations by model.", ["model"]
+    "django_model_updates_total", "Number of update operations by model.", ["model"],
+    namespace=NAMESPACE
 )
 
 model_deletes = Counter(
-    "django_model_deletes_total", "Number of delete operations by model.", ["model"]
+    "django_model_deletes_total", "Number of delete operations by model.", ["model"],
+    namespace=NAMESPACE
 )
 
 

--- a/django_prometheus/models.py
+++ b/django_prometheus/models.py
@@ -3,18 +3,24 @@ from prometheus_client import Counter
 from django_prometheus.conf import NAMESPACE
 
 model_inserts = Counter(
-    "django_model_inserts_total", "Number of insert operations by model.", ["model"],
-    namespace=NAMESPACE
+    "django_model_inserts_total",
+    "Number of insert operations by model.",
+    ["model"],
+    namespace=NAMESPACE,
 )
 
 model_updates = Counter(
-    "django_model_updates_total", "Number of update operations by model.", ["model"],
-    namespace=NAMESPACE
+    "django_model_updates_total",
+    "Number of update operations by model.",
+    ["model"],
+    namespace=NAMESPACE,
 )
 
 model_deletes = Counter(
-    "django_model_deletes_total", "Number of delete operations by model.", ["model"],
-    namespace=NAMESPACE
+    "django_model_deletes_total",
+    "Number of delete operations by model.",
+    ["model"],
+    namespace=NAMESPACE,
 )
 
 


### PR DESCRIPTION
Availability add namespaces to metrics by adding PROMETHEUS_METRIC_NAMESPACE variable to django settings