### PR TITLE
feat: Support for postgis database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,18 @@ services:
   - redis-server
   - mysql
   - postgresql
+addons:
+  postgresql: 9.5
+  apt:
+    packages:
+      - postgresql-9.5-postgis-2.4
+      - gdal-bin
 
 install:
   - pip install tox-travis coverage coveralls codacy-coverage
   - mysql -e 'create database django_prometheus_1;'
+  - psql -U postgres -c 'CREATE DATABASE postgis'
+  - psql -U postgres postgis -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
 script:
   - tox
 after_success:

--- a/django_prometheus/db/backends/postgis/base.py
+++ b/django_prometheus/db/backends/postgis/base.py
@@ -1,0 +1,17 @@
+import psycopg2.extensions
+from django.contrib.gis.db.backends.postgis import base
+from django_prometheus.db.common import DatabaseWrapperMixin, ExportingCursorWrapper
+
+
+class DatabaseWrapper(DatabaseWrapperMixin, base.DatabaseWrapper):
+    def get_connection_params(self):
+        conn_params = super(DatabaseWrapper, self).get_connection_params()
+        conn_params["cursor_factory"] = ExportingCursorWrapper(
+            psycopg2.extensions.cursor, "postgis", self.vendor,
+        )
+        return conn_params
+
+    def create_cursor(self, name=None):
+        # cursor_factory is a kwarg to connect() so restore create_cursor()'s
+        # default behavior
+        return base.DatabaseWrapper.create_cursor(self, name=name)

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -62,6 +62,15 @@ DATABASES = {
         "HOST": "localhost",
         "PORT": "5432",
     },
+    # Comment this to not test django_prometheus.db.backends.postgis.
+    "postgis": {
+        "ENGINE": "django_prometheus.db.backends.postgis",
+        "NAME": "postgis",
+        "USER": "postgres",
+        "PASSWORD": "",
+        "HOST": "localhost",
+        "PORT": "5432",
+    },
     # Comment this to not test django_prometheus.db.backends.mysql.
     "mysql": {
         "ENGINE": "django_prometheus.db.backends.mysql",


### PR DESCRIPTION
This adds support for PostGis database which is
also supported officially by django-- geodjango.

Refrences: https://github.com/korfuri/django-prometheus/pull/41 https://github.com/korfuri/django-prometheus/pull/90 https://github.com/korfuri/django-prometheus/pull/140