### PR TITLE
Fix Requests.is_ajax() deprecation warning in Django 3.1

### DIFF
--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -246,8 +246,11 @@ class PrometheusAfterMiddleware(MiddlewareMixin):
         self.label_metric(
             self.metrics.requests_by_transport, request, transport=transport
         ).inc()
-        if request.is_ajax():
+
+        # Mimic the behaviour of the deprecated "Request.is_ajax()" method.
+        if request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest":
             self.label_metric(self.metrics.requests_ajax, request).inc()
+
         content_length = int(request.META.get("CONTENT_LENGTH") or 0)
         self.label_metric(self.metrics.requests_body_bytes, request).observe(
             content_length


### PR DESCRIPTION
See the Django 3.1 release notes for information about deprecating the `Requests.is_ajax()` method.

```
django_prometheus/middleware.py:229: RemovedInDjango40Warning: request.is_ajax() is
deprecated. See Django 3.1 release notes for more details about this deprecation.
```

> The `HttpRequest.is_ajax()` method is deprecated as it relied on a jQuery-specific way of signifying AJAX calls, while current usage tends to use the JavaScript [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). Depending on your use case, you can either write your own AJAX detection method, or use the new [`HttpRequest.accepts()`](https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.HttpRequest.accepts) method if your code depends on the client `Accept` HTTP header.
>
> If you are writing your own AJAX detection method, `request.is_ajax()` can be reproduced exactly as `request.headers.get('x-requested-with') == 'XMLHttpRequest'`.

https://docs.djangoproject.com/en/3.1/releases/3.1/