### PR TITLE
Replace deprecated django.conf.urls.url()

### DIFF
--- a/django_prometheus/urls.py
+++ b/django_prometheus/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import path
 from django_prometheus import exports
 
 urlpatterns = [
-    url(r"^metrics$", exports.ExportToDjangoView, name="prometheus-django-metrics")
+    path("metrics", exports.ExportToDjangoView, name="prometheus-django-metrics")
 ]


### PR DESCRIPTION
Fix RemovedInDjango40Warning deprecation warning

https://code.djangoproject.com/ticket/31534