### PR TITLE
Added the setting to protect the /metrics endpoint

### DIFF
--- a/django_prometheus/tests/end2end/testapp/test_authorization.py
+++ b/django_prometheus/tests/end2end/testapp/test_authorization.py
@@ -1,36 +1,48 @@
+import base64
+
 from django.test import TestCase, Client
 from django.conf import settings
 
 
+EXPECTED_USERNAME = "prometheus"
+EXPECTED_PASSWORD = "secret"
+
+
 class TestProtectedMetrics(TestCase):
-    def test_token_not_set__success_response(self):
+    def test_credentials_not_set__success_response(self):
         c = Client()
         # Assure there's no expected token
-        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", None)
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_USERNAME", None)
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_PASSWORD", None)
 
         response = c.get("/metrics")
         self.assertEqual(200, response.status_code)
         self.assertContains(response, "python_info{")
 
-    def test_wrong_token__unauthorized_response(self):
-        expected_token = "top_secret_string"
-        c = Client(HTTP_AUTHORIZATION="Bearer incorrec_value_for_token")
-        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", expected_token)
+    def test_bad_auth_string__bad_request_response(self):
+        c = Client(HTTP_AUTHORIZATION=f"Basic d3Jvbmc=")
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_USERNAME", EXPECTED_USERNAME)
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_PASSWORD", EXPECTED_PASSWORD)
 
-        response = c.get("/metrics")
-        self.assertEqual(len(response.content), 0)
-
-    def test_correct_token_wrong_type__bad_request_response(self):
-        expected_token = "top_secret_string"
-        c = Client(HTTP_AUTHORIZATION=f"WRONG_TYPE {expected_token}")
-        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", expected_token)
         response = c.get("/metrics")
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(len(response.content), 0)
 
-    def test_correct_token_and_type__success_response(self):
-        expected_token = "top_secret_string"
-        c = Client(HTTP_AUTHORIZATION=f"Bearer {expected_token}")
-        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", expected_token)
+    def test_bad_credentials__unauthorized_response(self):
+        c = Client(HTTP_AUTHORIZATION=f"Basic dXNlcjp3cm9uZ3Bhc3M=")
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_USERNAME", EXPECTED_USERNAME)
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_PASSWORD", EXPECTED_PASSWORD)
+
+        response = c.get("/metrics")
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(len(response.content), 0)
+
+    def test_correct_credentials__success_response(self):
+        auth_string = f'{EXPECTED_USERNAME}:{EXPECTED_PASSWORD}'
+        expected_auth = base64.b64encode(auth_string.encode()).decode()
+        c = Client(HTTP_AUTHORIZATION=f"Basic {expected_auth}")
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_USERNAME", EXPECTED_USERNAME)
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_PASSWORD", EXPECTED_PASSWORD)
+
         response = c.get("/metrics")
         self.assertEqual(response.status_code, 200)
-        self.assertNotEqual(len(response.content), 0)

--- a/django_prometheus/tests/end2end/testapp/test_authorization.py
+++ b/django_prometheus/tests/end2end/testapp/test_authorization.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, Client
+from django.conf import settings
+
+
+class TestProtectedMetrics(TestCase):
+    def test_token_not_set__success_response(self):
+        c = Client()
+        # Assure there's no expected token
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", None)
+
+        response = c.get("/metrics")
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, "python_info{")
+
+    def test_wrong_token__unauthorized_response(self):
+        expected_token = "top_secret_string"
+        c = Client(HTTP_AUTHORIZATION="Bearer incorrec_value_for_token")
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", expected_token)
+
+        response = c.get("/metrics")
+        self.assertEqual(len(response.content), 0)
+
+    def test_correct_token_wrong_type__bad_request_response(self):
+        expected_token = "top_secret_string"
+        c = Client(HTTP_AUTHORIZATION=f"WRONG_TYPE {expected_token}")
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", expected_token)
+        response = c.get("/metrics")
+        self.assertEqual(response.status_code, 400)
+
+    def test_correct_token_and_type__success_response(self):
+        expected_token = "top_secret_string"
+        c = Client(HTTP_AUTHORIZATION=f"Bearer {expected_token}")
+        setattr(settings, "DJANGO_PROMETHEUS_AUTHORIZATION_TOKEN", expected_token)
+        response = c.get("/metrics")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(len(response.content), 0)


### PR DESCRIPTION
Modified the 'ExportToDjangoView' so that when the variables

```
DJANGO_PROMETHEUS_AUTHORIZATION_USERNAME
DJANGO_PROMETHEUS_AUTHORIZATION_PASSWORD
```

are declared on `settings.py` and have a variable different than `None`

Metrics will only be retrieved when the request have basic authentication set
to the expected values