### PR TITLE
Use default registry when `prometheus_multiproc_dir` is set

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -117,7 +117,7 @@ def ExportToDjangoView(request):
     You can use django_prometheus.urls to map /metrics to this view.
     """
     if "prometheus_multiproc_dir" in os.environ:
-        registry = prometheus_client.CollectorRegistry()
+        registry = prometheus_client.REGISTRY
         multiprocess.MultiProcessCollector(registry)
     else:
         registry = prometheus_client.REGISTRY


### PR DESCRIPTION
This should allow custom metrics to be used when this envvar is set (unless I've missed something and they can already)