### PR TITLE
fix dev/pre-release version

### DIFF
--- a/django_prometheus/__init__.py
+++ b/django_prometheus/__init__.py
@@ -11,7 +11,7 @@ from django_prometheus import middleware, models
 
 __all__ = ["middleware", "models", "pip_prometheus"]
 
-__version__ = "2.2.0.dev"
+__version__ = "2.2.0.dev0"
 
 # Import pip_prometheus to export the pip metrics automatically.
 try:


### PR DESCRIPTION
The old way of specifying the pre-release version results in a deprecation warning hence this change