### PR TITLE
Fix django deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In your urls.py:
 ```python
 urlpatterns = [
     ...
-    url('', include('django_prometheus.urls')),
+    path('', include('django_prometheus.urls')),
 ]
 ```
 

--- a/django_prometheus/tests/end2end/testapp/urls.py
+++ b/django_prometheus/tests/end2end/testapp/urls.py
@@ -1,15 +1,15 @@
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path, re_path
 from testapp import views
 
 urlpatterns = [
-    url(r"^$", views.index),
-    url(r"^help$", views.help),
-    url(r"^slow$", views.slow, name="slow"),
-    url(r"^objection$", views.objection),
-    url(r"^sql$", views.sql),
-    url(r"^newlawn/(?P<location>[a-zA-Z0-9 ]+)$", views.newlawn),
-    url(r"^file$", views.file),
-    url("", include("django_prometheus.urls")),
-    url(r"^admin/", admin.site.urls),
+    re_path(r"^$", views.index),
+    re_path(r"^help$", views.help),
+    re_path(r"^slow$", views.slow, name="slow"),
+    re_path(r"^objection$", views.objection),
+    re_path(r"^sql$", views.sql),
+    re_path(r"^newlawn/(?P<location>[a-zA-Z0-9 ]+)$", views.newlawn),
+    re_path(r"^file$", views.file),
+    path("", include("django_prometheus.urls")),
+    re_path(r"^admin/", admin.site.urls),
 ]

--- a/documentation/exports.md
+++ b/documentation/exports.md
@@ -8,7 +8,7 @@ include('django_prometheus.urls') with no prefix like so:
 ```python
 urlpatterns = [
     ...
-    url('', include('django_prometheus.urls')),
+    path('', include('django_prometheus.urls')),
 ]
 ```
 
@@ -20,7 +20,7 @@ need to configure Prometheus to use that path instead of the default.
 ```python
 urlpatterns = [
     ...
-    url('^monitoring/', include('django_prometheus.urls')),
+    path('monitoring/', include('django_prometheus.urls')),
 ]
 ```
 


### PR DESCRIPTION
```  django_prometheus/tests/end2end/testapp/test_middleware.py::TestMiddlewareMetrics::test_exception_latency_histograms
    /home/runner/work/django-prometheus/django-prometheus/django_prometheus/tests/end2end/testapp/urls.py:14: RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
      url(r"^admin/", admin.site.urls),
```
https://github.com/asherf/django-prometheus/runs/4127895607?check_suite_focus=true#step:8:857