### PR TITLE
Replace python-memcached with pylibmc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         pip install -U "pip>=21.1"
         pip install -U setuptools "tox>=3.23.0,<4" codecov tox-gh-actions coverage
         sudo apt-get update
-        sudo apt-get install binutils libproj-dev gdal-bin
+        sudo apt-get install binutils libproj-dev gdal-bin libmemcached-dev
     - name: Log versions
       run: |
         python --version

--- a/django_prometheus/cache/backends/memcached.py
+++ b/django_prometheus/cache/backends/memcached.py
@@ -7,7 +7,7 @@ from django_prometheus.cache.metrics import (
 )
 
 
-class MemcachedCache(memcached.MemcachedCache):
+class MemcachedCache(memcached.PyMemcacheCache):
     """Inherit memcached to add metrics about hit/miss ratio"""
 
     def get(self, key, default=None, version=None):

--- a/django_prometheus/cache/backends/memcached.py
+++ b/django_prometheus/cache/backends/memcached.py
@@ -7,7 +7,7 @@ from django_prometheus.cache.metrics import (
 )
 
 
-class MemcachedCache(memcached.PyMemcacheCache):
+class MemcachedCache(memcached.PyLibMCCache):
     """Inherit memcached to add metrics about hit/miss ratio"""
 
     def get(self, key, default=None, version=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ mysqlclient
 psycopg2
 pytest==6.2.5
 pytest-django
-python-memcached
+pymemcache

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ mysqlclient
 psycopg2
 pytest==6.2.5
 pytest-django
-pymemcache
+pylibmc


### PR DESCRIPTION
MemcachedCache is being deprecated since `python-memcached` is not maintained (no release since 2017)
https://pypi.org/project/python-memcached/#history