### PR TITLE
remove deprecated isort option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
 commands =
     black --check django_prometheus/
     flake8 django_prometheus
-    isort --check-only -rc django_prometheus/
+    isort --check-only django_prometheus/
 
 [flake8]
 ignore = E501,W503


### PR DESCRIPTION
https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html#migrating-cli-options