### PR TITLE
Use the SPDX short identifier for the license name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="Uriel Corfa",
     author_email="uriel@corfa.fr",
     description=("Django middlewares to monitor your application with Prometheus.io."),
-    license="Apache",
+    license="Apache-2.0",
     keywords="django monitoring prometheus",
     url="http://github.com/korfuri/django-prometheus",
     project_urls={


### PR DESCRIPTION
Many packages are now using the SPDX short name for license (in line with PEP
639), to make it easier for third party tools to parse this information.

By updating this, other tools will be able to identify the exact license
django-prometheus is using.