### PR TITLE
Support all cache backends of Django >=3.2

### DIFF
--- a/django_prometheus/cache/backends/memcached.py
+++ b/django_prometheus/cache/backends/memcached.py
@@ -1,3 +1,4 @@
+from django import VERSION as DJANGO_VERSION
 from django.core.cache.backends import memcached
 
 from django_prometheus.cache.metrics import (
@@ -7,9 +8,7 @@ from django_prometheus.cache.metrics import (
 )
 
 
-class MemcachedCache(memcached.PyLibMCCache):
-    """Inherit memcached to add metrics about hit/miss ratio"""
-
+class MemcachedPrometheusCacheMixin:
     def get(self, key, default=None, version=None):
         django_cache_get_total.labels(backend="memcached").inc()
         cached = super().get(key, default=None, version=version)
@@ -18,3 +17,22 @@ class MemcachedCache(memcached.PyLibMCCache):
         else:
             django_cache_misses_total.labels(backend="memcached").inc()
         return cached or default
+
+
+class MemcachedCache(MemcachedPrometheusCacheMixin, memcached.MemcachedCache):
+    """Inherit memcached to add metrics about hit/miss ratio"""
+
+    pass
+
+
+if DJANGO_VERSION >= (3, 2):
+
+    class PyLibMCCache(MemcachedPrometheusCacheMixin, memcached.PyLibMCCache):
+        """Inherit memcached to add metrics about hit/miss ratio"""
+
+        pass
+
+    class PyMemcacheCache(MemcachedPrometheusCacheMixin, memcached.PyMemcacheCache):
+        """Inherit memcached to add metrics about hit/miss ratio"""
+
+        pass

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+from django import VERSION as DJANGO_VERSION
 from testapp.helpers import get_middleware
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -99,7 +100,7 @@ CACHES = {
         "BACKEND": "django_prometheus.cache.backends.memcached.MemcachedCache",
         "LOCATION": "localhost:11211",
     },
-    "memcached": {
+    "memcached.MemcachedCache": {
         "BACKEND": "django_prometheus.cache.backends.memcached.MemcachedCache",
         "LOCATION": "localhost:11211",
     },
@@ -126,6 +127,17 @@ CACHES = {
         "OPTIONS": {"IGNORE_EXCEPTIONS": True},
     },
 }
+
+
+if DJANGO_VERSION >= (3, 2):
+    CACHES["memcached.PyLibMCCache"] = {
+        "BACKEND": "django_prometheus.cache.backends.memcached.PyLibMCCache",
+        "LOCATION": "localhost:11211",
+    }
+    CACHES["memcached.PyMemcacheCache"] = {
+        "BACKEND": "django_prometheus.cache.backends.memcached.PyMemcacheCache",
+        "LOCATION": "localhost:11211",
+    }
 
 # Internationalization
 LANGUAGE_CODE = "en-us"

--- a/django_prometheus/tests/test_testutils.py
+++ b/django_prometheus/tests/test_testutils.py
@@ -61,18 +61,15 @@ class PrometheusTestCaseMixinTest(unittest.TestCase):
         vector = self.test_case.getMetricVector(
             "some_labelled_gauge", registry=self.registry
         )
-        assert (
-            sorted(
-                [
-                    ({"labelred": "pink", "labelblue": "indigo"}, 1),
-                    ({"labelred": "pink", "labelblue": "royal"}, 2),
-                    ({"labelred": "carmin", "labelblue": "indigo"}, 3),
-                    ({"labelred": "carmin", "labelblue": "royal"}, 4),
-                ],
-                key=itemgetter(1),
-            )
-            == sorted(vector, key=itemgetter(1))
-        )
+        assert sorted(
+            [
+                ({"labelred": "pink", "labelblue": "indigo"}, 1),
+                ({"labelred": "pink", "labelblue": "royal"}, 2),
+                ({"labelred": "carmin", "labelblue": "indigo"}, 3),
+                ({"labelred": "carmin", "labelblue": "royal"}, 4),
+            ],
+            key=itemgetter(1),
+        ) == sorted(vector, key=itemgetter(1))
 
     def testAssertMetricEquals(self):
         """Tests assertMetricEquals."""

--- a/django_prometheus/utils.py
+++ b/django_prometheus/utils.py
@@ -24,6 +24,6 @@ def TimeSince(t):
 def PowersOf(logbase, count, lower=0, include_zero=True):
     """Returns a list of count powers of logbase (from logbase**lower)."""
     if not include_zero:
-        return [logbase ** i for i in range(lower, count + lower)]
+        return [logbase**i for i in range(lower, count + lower)]
     else:
-        return [0] + [logbase ** i for i in range(lower, count + lower)]
+        return [0] + [logbase**i for i in range(lower, count + lower)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ psycopg2
 pytest==6.2.5
 pytest-django
 pylibmc
+pymemcache
+python-memcached

--- a/setup.py
+++ b/setup.py
@@ -26,19 +26,25 @@ setup(
     keywords="django monitoring prometheus",
     url="http://github.com/korfuri/django-prometheus",
     project_urls={
-            "Changelog": "https://github.com/korfuri/django-prometheus/blob/master/CHANGELOG.md",
-            "Documentation": "https://github.com/korfuri/django-prometheus/blob/master/README.md",
-            "Source": "https://github.com/korfuri/django-prometheus",
-            "Tracker": "https://github.com/korfuri/django-prometheus/issues",
+        "Changelog": "https://github.com/korfuri/django-prometheus/blob/master/CHANGELOG.md",
+        "Documentation": "https://github.com/korfuri/django-prometheus/blob/master/README.md",
+        "Source": "https://github.com/korfuri/django-prometheus",
+        "Tracker": "https://github.com/korfuri/django-prometheus/issues",
     },
-    packages=find_packages(exclude=["tests",]),
+    packages=find_packages(
+        exclude=[
+            "tests",
+        ]
+    ),
     test_suite="django_prometheus.tests",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     tests_require=["pytest", "pytest-django"],
     setup_requires=["pytest-runner"],
     options={"bdist_wheel": {"universal": "1"}},
-    install_requires=["prometheus-client>=0.7",],
+    install_requires=[
+        "prometheus-client>=0.7",
+    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/update_version_from_git.py
+++ b/update_version_from_git.py
@@ -78,7 +78,7 @@ def get_git_version_info():
 
 
 def prerelease_version():
-    """ return what the prerelease version should be.
+    """return what the prerelease version should be.
     https://packaging.python.org/tutorials/distributing-packages/#pre-release-versioning
     0.0.2.dev22
     """


### PR DESCRIPTION
When upgrading to Django 3.2, the django-prometheus package caused some issues because it forces the user to use the PyLibMCCache without making the implicit requirement of pylibmc transparent to the user or directly requiring the package (introduced by #296). Additionally, the deprecation warning is hidden from the user.

Django 3.2 gives the user the option to keep on using the deprecated backend, and also adds another cache backend than the pylibmc-based one.

This merge request adds support for all cache backends of Django 3.2 and lets the user choose between them according to the official Django documentation.

This closes issue #328