### PR TITLE
Fix two latency metrics not using PROMETHEUS_LATENCY_BUCKETS setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ urlpatterns = [
 ### Configuration
 
 Prometheus uses Histogram based grouping for monitoring latencies. The default
-buckets are here: https://github.com/prometheus/client_python/blob/master/prometheus_client/core.py
+buckets are:
+```python
+PROMETHEUS_LATENCY_BUCKETS = (0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 25.0, 50.0, 75.0, float("inf"),)
+```
 
 You can define custom buckets for latency, adding more buckets decreases performance but
 increases accuracy: https://prometheus.io/docs/practices/histograms/

--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -2,5 +2,26 @@ from django.conf import settings
 
 NAMESPACE = ""
 
+PROMETHEUS_LATENCY_BUCKETS = (
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+    25.0,
+    50.0,
+    75.0,
+    float("inf"),
+)
+
 if settings.configured:
     NAMESPACE = getattr(settings, "PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)
+    PROMETHEUS_LATENCY_BUCKETS = getattr(settings, "PROMETHEUS_LATENCY_BUCKETS", PROMETHEUS_LATENCY_BUCKETS)

--- a/django_prometheus/db/metrics.py
+++ b/django_prometheus/db/metrics.py
@@ -1,6 +1,6 @@
 from prometheus_client import Counter, Histogram
 
-from django_prometheus.conf import NAMESPACE
+from django_prometheus.conf import NAMESPACE, PROMETHEUS_LATENCY_BUCKETS
 
 connections_total = Counter(
     "django_db_new_connections_total",
@@ -46,5 +46,6 @@ query_duration_seconds = Histogram(
     "django_db_query_duration_seconds",
     ("Histogram of query duration by database and vendor."),
     ["alias", "vendor"],
+    buckets=PROMETHEUS_LATENCY_BUCKETS,
     namespace=NAMESPACE,
 )

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -2,28 +2,8 @@ from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from prometheus_client import Counter, Histogram
 
-from django_prometheus.conf import NAMESPACE
+from django_prometheus.conf import NAMESPACE, PROMETHEUS_LATENCY_BUCKETS
 from django_prometheus.utils import PowersOf, Time, TimeSince
-
-DEFAULT_LATENCY_BUCKETS = (
-    0.01,
-    0.025,
-    0.05,
-    0.075,
-    0.1,
-    0.25,
-    0.5,
-    0.75,
-    1.0,
-    2.5,
-    5.0,
-    7.5,
-    10.0,
-    25.0,
-    50.0,
-    75.0,
-    float("inf"),
-)
 
 
 class Metrics:
@@ -61,6 +41,7 @@ class Metrics:
                 "Histogram of requests processing time (including middleware "
                 "processing time)."
             ),
+            buckets=PROMETHEUS_LATENCY_BUCKETS,
             namespace=NAMESPACE,
         )
         self.requests_unknown_latency_before = self.register_metric(
@@ -77,9 +58,7 @@ class Metrics:
             "django_http_requests_latency_seconds_by_view_method",
             "Histogram of request processing time labelled by view.",
             ["view", "method"],
-            buckets=getattr(
-                settings, "PROMETHEUS_LATENCY_BUCKETS", DEFAULT_LATENCY_BUCKETS
-            ),
+            buckets=PROMETHEUS_LATENCY_BUCKETS,
             namespace=NAMESPACE,
         )
         self.requests_unknown_latency = self.register_metric(


### PR DESCRIPTION
`django_http_requests_latency_including_middlewares_seconds` and `django_db_query_duration_seconds` don't use the `PROMETHEUS_LATENCY_BUCKETS` setting  and also the default for `django_http_requests_latency_seconds_by_view_method` is not the default that python prometheus client uses. 

I used the default that was used for `django_http_requests_latency_seconds_by_view_method` and moved it to conf module and then used that config in histograms mentioned above.