### PR TITLE
Fix postgres import

### DIFF
--- a/django_prometheus/db/backends/postgresql/base.py
+++ b/django_prometheus/db/backends/postgresql/base.py
@@ -1,4 +1,4 @@
-from django.contrib.gis.db.backends.postgis import base
+from django.contrib.gis.db.backends.postgresql import base
 
 from django_prometheus.db.backends.common import get_postgres_cursor_class
 from django_prometheus.db.common import DatabaseWrapperMixin, ExportingCursorWrapper

--- a/django_prometheus/db/backends/postgresql/base.py
+++ b/django_prometheus/db/backends/postgresql/base.py
@@ -1,4 +1,4 @@
-from django.contrib.gis.db.backends.postgresql import base
+from django.db.backends.postgresql import base
 
 from django_prometheus.db.backends.common import get_postgres_cursor_class
 from django_prometheus.db.common import DatabaseWrapperMixin, ExportingCursorWrapper


### PR DESCRIPTION
PostgreSQL backend was somehow importing PostGIS, which caused unexpected import errors in Django users.