### PR TITLE
fix(exports): use try except to handle port in use by django gunicorn

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -42,8 +42,11 @@ def SetupPrometheusEndpointOnPort(port, addr=""):
         "autoreloader is active. Use the URL exporter, or start django "
         "with --noreload. See documentation/exports.md."
     )
+
+    registry = prometheus_client.CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
     try:
-        prometheus_client.start_http_server(port, addr=addr)
+        prometheus_client.start_http_server(port, addr=addr, registry=registry)
     except OSError:
         """
         first process serves metrics on port 8001, other processes raise error: port already in use

--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -42,7 +42,13 @@ def SetupPrometheusEndpointOnPort(port, addr=""):
         "autoreloader is active. Use the URL exporter, or start django "
         "with --noreload. See documentation/exports.md."
     )
-    prometheus_client.start_http_server(port, addr=addr)
+    try:
+        prometheus_client.start_http_server(port, addr=addr)
+    except OSError:
+        """
+        first process serves metrics on port 8001, other processes raise error: port already in use
+        one processes collect metrics from PROMETHEUS_MULTIPROC_DIR
+        """
 
 
 class PrometheusEndpointServer(threading.Thread):


### PR DESCRIPTION
Hi,

Thank you guys for your very powerful library, You are GREAT!

When we run gunicorn command to serve django app, the command is

`gunicorn APP.wsgi:application --name APP --workers 4 --bind=0.0.0.0:8000 --log-level=INFO --log-file=- `

then 4 process runs this part of code, one of them allocates metrics on the `PROMETHEUS_METRICS_EXPORT_PORT`
and if one of them allocates, this is enough for the rest, because all other processes write their metrics in `PROMETHEUS_MULTIPROC_DIR` 

i had this workaround in my django to solve this issue

```python

if config("PROMETHEUS_ENABLE", cast=bool, default=False):
    # there was a bug here. when we import libs and then assign env variables, the metrics didnt store
    
    PROMETHEUS_MULTIPROC_DIR = config("PROMETHEUS_MULTIPROC_DIR")
    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
        os.environ["PROMETHEUS_MULTIPROC_DIR"] = config("PROMETHEUS_MULTIPROC_DIR")
    if not os.path.exists(PROMETHEUS_MULTIPROC_DIR):
        os.makedirs(PROMETHEUS_MULTIPROC_DIR)

    from prometheus_client.multiprocess import MultiProcessCollector
    from prometheus_client import CollectorRegistry, start_http_server
    
    INSTALLED_APPS += ["django_prometheus"]
    MIDDLEWARE.insert(0, "django_prometheus.middleware.PrometheusBeforeMiddleware")
    MIDDLEWARE.append("django_prometheus.middleware.PrometheusAfterMiddleware")
    
    
    registry = CollectorRegistry()
    MultiProcessCollector(registry)
    try:
        start_http_server(8001, registry=registry)
    except OSError:
        """
        first process serves metrics on port 8001, other processes raise error: port already in use
        one processes collect metrics from PROMETHEUS_MULTIPROC_DIR
        """

```

this workaround dosen't work on celery processes, we need to run these
`export PROMETHEUS_MULTIPROC_DIR=PATH/TO/`
`celery ....`

when we set this env variable on OS layer, we can use this code in our backend
```python
if config("PROMETHEUS_ENABLE", cast=bool, default=False):
    PROMETHEUS_METRICS_EXPORT_PORT = 8001
    PROMETHEUS_METRICS_EXPORT_ADDRESS = "0.0.0.0"
    INSTALLED_APPS += ["django_prometheus"]
    MIDDLEWARE.insert(0, "django_prometheus.middleware.PrometheusBeforeMiddleware")
    MIDDLEWARE.append("django_prometheus.middleware.PrometheusAfterMiddleware")

```

I still checking python client to solve the issue,