### PR TITLE
Support Django's official Redis cache backend.

### DIFF
--- a/django_prometheus/cache/backends/redis.py
+++ b/django_prometheus/cache/backends/redis.py
@@ -1,5 +1,5 @@
+from django import VERSION as DJANGO_VERSION
 from django_redis import cache, exceptions
-
 from django_prometheus.cache.metrics import (
     django_cache_get_fail_total,
     django_cache_get_total,
@@ -29,4 +29,24 @@ class RedisCache(cache.RedisCache):
                 return cached
             else:
                 django_cache_misses_total.labels(backend="redis").inc()
+                return default
+
+
+if DJANGO_VERSION >= (4, 0):
+    from django.core.cache.backends.redis import RedisCache as DjangoRedisCache
+
+    class NativeRedisCache(DjangoRedisCache):
+
+        def get(self, key, default=None, version=None):
+            django_cache_get_total.labels(backend="native_redis").inc()
+            try:
+                result = super().get(key, default=None, version=version)
+            except Exception:
+                django_cache_get_fail_total.labels(backend="native_redis").inc()
+                raise
+            if result is not None:
+                django_cache_hits_total.labels(backend="native_redis").inc()
+                return result
+            else:
+                django_cache_misses_total.labels(backend="native_redis").inc()
                 return default

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+from django import VERSION as DJANGO_VERSION
+
 from testapp.helpers import get_middleware
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -130,6 +132,12 @@ CACHES = {
         "OPTIONS": {"IGNORE_EXCEPTIONS": True},
     },
 }
+
+if DJANGO_VERSION >= (4, 0):
+    CACHES["native_redis"] = {
+        "BACKEND": "django_prometheus.cache.backends.redis.NativeRedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/0",
+    }
 
 
 # Internationalization

--- a/django_prometheus/tests/end2end/testapp/test_caches.py
+++ b/django_prometheus/tests/end2end/testapp/test_caches.py
@@ -1,10 +1,13 @@
 import pytest
 from django.core.cache import caches
+from django import VERSION as DJANGO_VERSION
 from redis import RedisError
 
 from django_prometheus.testutils import assert_metric_equal, get_metric
 
 _SUPPORTED_CACHES = ["memcached.PyLibMCCache", "memcached.PyMemcacheCache", "filebased", "locmem", "redis"]
+if DJANGO_VERSION >= (4, 0):
+    _SUPPORTED_CACHES.append("native_redis")
 
 
 class TestCachesMetrics:


### PR DESCRIPTION
Django added Redis cache backend since 4.0.
I added the backend but I thinks maybe there is better way for naming! Now the old `django_redis` backend is called `RedisCache` (I left it intact for backward compatibility) and I named the new one `NativeRedisCache`.

If you thinks there is better option for naming or anything else, just let me know.

Thanks
 