### PR TITLE
Fixed incompatibility with django-redis >= 4.12.0

### DIFF
--- a/django_prometheus/cache/backends/redis.py
+++ b/django_prometheus/cache/backends/redis.py
@@ -1,5 +1,6 @@
 from django_redis import cache, exceptions
 
+
 from django_prometheus.cache.metrics import (
     django_cache_get_fail_total,
     django_cache_get_total,
@@ -20,7 +21,7 @@ class RedisCache(cache.RedisCache):
             django_cache_get_fail_total.labels(backend="redis").inc()
             if self._ignore_exceptions:
                 if self._log_ignored_exceptions:
-                    cache.logger.error(str(e))
+                    self.logger.error(str(e))
                 return default
             raise
         else:


### PR DESCRIPTION
Fixed bug caused by trying to use global level logger variable from django_redis.cache that has been moved to django_redis.cache.RedisCache instance attribute since django-redis 4.12.0 release.

django-redis package allows to ignore cache exceptions by setting the `"IGNORE_EXCEPTIONS": True` key in the cache options in settings.py:
```
CACHES = {
    "default": {
        # ...
        "OPTIONS": {
            "IGNORE_EXCEPTIONS": True,
        }
    }
}
```
or by defining the following global variable in settings.py:
```
DJANGO_REDIS_IGNORE_EXCEPTIONS = True
```

When ignoring exceptions with `IGNORE_EXCEPTIONS` or `DJANGO_REDIS_IGNORE_EXCEPTIONS`, you may optionally log exceptions using the global variable `DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS` in your settings file:
```
DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
```
django_prometheus RedisCache wrapper class respects these settings by inheriting them from `django_redis.cache.RedisCache`. However, in case when "ignore exceptions, but log them" strategy is used, django_prometheus RedisCache wrapper tries to access the global variable `django_redis.cache.logger`. Unfortunately, this variable has been moved from global variable to `django_redis.cache.RedisCache` instance attribute since django-redis 4.12.0 release (specifically by this commit https://github.com/jazzband/django-redis/commit/b7d64f0a80180ecfe8900407fbdf5e4196fa7a2a).

This commit fixes the bug simply by changing the reference to logger from `django_redis.cache.logger` global variable to the instance attribute logger inherited by django_prometheus RedisCache wrapper.