### PR TITLE
README: migration metrics are disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ are exported, `django_migrations_applied_by_connection` and
 `django_migrations_unapplied_by_connection`. You may want to alert if
 there are unapplied migrations.
 
-If you want to disable the Django migration metrics, set the
-`PROMETHEUS_EXPORT_MIGRATIONS` setting to False.
+This behavior is disabled by default. To enable it, set
+`PROMETHEUS_EXPORT_MIGRATIONS` in your `settings.py` to
+`True`.
 
 ### Monitoring and aggregating the metrics
 


### PR DESCRIPTION
The docs are misleading here, make it clear that this needs to be enabled explicitly since ac0204cdd24c87850e97296e6f2d185017b57634.

cc @asherf 