### PR TITLE
Fix Redis backend to not require django_redis

### DIFF
--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -135,7 +135,7 @@ CACHES = {
 
 if DJANGO_VERSION >= (4, 0):
     CACHES["native_redis"] = {
-        "BACKEND": "django_prometheus.cache.backends.redis.NativeRedisCache",
+        "BACKEND": "django_prometheus.cache.backends.redis.RedisNativeCache",
         "LOCATION": "redis://127.0.0.1:6379/0",
     }
 


### PR DESCRIPTION
- Handle `django_redis` not installed when not needed, we could also move it to a separate file
- Rename `NativeRedisCache ` to `RedisNativeCache` (I thought it's better to keep then in sync, otherwise I can revert that)