### PR TITLE
Fix use multi process for load metrics

### DIFF
--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -42,8 +42,11 @@ def SetupPrometheusEndpointOnPort(port, addr=""):
         "autoreloader is active. Use the URL exporter, or start django "
         "with --noreload. See documentation/exports.md."
     )
+
+    registry = prometheus_client.CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
     try:
-        prometheus_client.start_http_server(port, addr=addr)
+        prometheus_client.start_http_server(port, addr=addr, registry=registry)
     except OSError:
         """
         first process serves metrics on port 8001, other processes raise error: port already in use

--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -42,7 +42,13 @@ def SetupPrometheusEndpointOnPort(port, addr=""):
         "autoreloader is active. Use the URL exporter, or start django "
         "with --noreload. See documentation/exports.md."
     )
-    prometheus_client.start_http_server(port, addr=addr)
+    try:
+        prometheus_client.start_http_server(port, addr=addr)
+    except OSError:
+        """
+        first process serves metrics on port 8001, other processes raise error: port already in use
+        one processes collect metrics from PROMETHEUS_MULTIPROC_DIR
+        """
 
 
 class PrometheusEndpointServer(threading.Thread):

--- a/django_prometheus/exports.py
+++ b/django_prometheus/exports.py
@@ -43,8 +43,12 @@ def SetupPrometheusEndpointOnPort(port, addr=""):
         "with --noreload. See documentation/exports.md."
     )
 
-    registry = prometheus_client.CollectorRegistry()
-    multiprocess.MultiProcessCollector(registry)
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ or "prometheus_multiproc_dir" in os.environ:
+        registry = prometheus_client.CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry)
+    else:
+        registry = prometheus_client.REGISTRY
+    
     try:
         prometheus_client.start_http_server(port, addr=addr, registry=registry)
     except OSError:


### PR DESCRIPTION
Hi,

I opened a pull request (https://github.com/korfuri/django-prometheus/pull/407) that was closed. I think I need to explain the problem in more detail.

The first problem is with using the `PROMETHEUS_METRICS_EXPORT_PORT` and `PROMETHEUS_METRICS_EXPORT_ADDRESS` environment variables. Here is the command that starts my app:
```bash
gunicorn APP.wsgi:application --name APP --workers 4 --bind=0.0.0.0:8000 --log-level=INFO --log-file=- 
```
The first error we encounter is `Address already in use` because in `exports.py`, line 45, the function `prometheus_client.start_http_server(port, addr=addr)` is called without checking if the port is already in use. This should be handled with a `try-except` block.

The second problem is when we use the `PROMETHEUS_MULTIPROC_DIR` environment variable. The function `SetupPrometheusEndpointOnPort` does not check `PROMETHEUS_MULTIPROC_DIR` and only runs this:
```python
prometheus_client.start_http_server(port, addr=addr)
```
The implementation of this part must be similar to `ExportToDjangoView`. I mistakenly forced the app to use `PROMETHEUS_MULTIPROC_DIR`, but I have fixed it.

Thank you for your attention. Please tell me where I am wrong about it.