### PR TITLE
Fix CI

### DIFF
--- a/django_prometheus/cache/backends/redis.py
+++ b/django_prometheus/cache/backends/redis.py
@@ -1,5 +1,6 @@
 from django import VERSION as DJANGO_VERSION
 from django_redis import cache, exceptions
+
 from django_prometheus.cache.metrics import (
     django_cache_get_fail_total,
     django_cache_get_total,
@@ -36,7 +37,6 @@ if DJANGO_VERSION >= (4, 0):
     from django.core.cache.backends.redis import RedisCache as DjangoRedisCache
 
     class NativeRedisCache(DjangoRedisCache):
-
         def get(self, key, default=None, version=None):
             django_cache_get_total.labels(backend="native_redis").inc()
             try:

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 
 from django import VERSION as DJANGO_VERSION
-
 from testapp.helpers import get_middleware
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/django_prometheus/tests/end2end/testapp/test_caches.py
+++ b/django_prometheus/tests/end2end/testapp/test_caches.py
@@ -1,6 +1,6 @@
 import pytest
-from django.core.cache import caches
 from django import VERSION as DJANGO_VERSION
+from django.core.cache import caches
 from redis import RedisError
 
 from django_prometheus.testutils import assert_metric_equal, get_metric

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools >= 67.7.2", "wheel >= 0.40.0"]
+requires = ["setuptools >= 67.7.2, < 72.0.0", "wheel >= 0.40.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
@@ -24,8 +24,8 @@ legacy_tox_ini = """
 min_version = 4.4
 envlist =
     {py37,py38,py39,py310,py311}-django{320}-{end2end,unittests}
-    {py38,py39,py310,py311,312}-django{400,410,420}-{end2end,unittests}
-    {py310,py311,312}-django{500}-{end2end,unittests}
+    {py38,py39,py310,py311,py312}-django{400,410,420}-{end2end,unittests}
+    {py310,py311,py312}-django{500}-{end2end,unittests}
     py39-lint
 
 [gh-actions]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytest-django
 pylibmc
 pymemcache
 python-memcached
-setuptools
+setuptools<72.0.0
 wheel


### PR DESCRIPTION
- setuptools >= 72.0.0 does [not](https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7200) have support for `test` command anymore, thus pinning setuptools < 72.0.0
- Python 3.12 seems to have been defined incorrectly in tox `envlist`, so no tests were ever executed for Python 3.12. Fixing these
- fixing some formatting black and isort were complaining about