### PR TITLE
Add support for spatialite database backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-22.04]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
     services:
@@ -44,7 +44,7 @@ jobs:
     - name: Install OS Packages
       run: |
         sudo apt-get update
-        sudo apt-get install binutils libproj-dev gdal-bin libmemcached-dev
+        sudo apt-get install binutils libproj-dev gdal-bin libmemcached-dev libsqlite3-mod-spatialite
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/django_prometheus/db/backends/spatialite/base.py
+++ b/django_prometheus/db/backends/spatialite/base.py
@@ -1,0 +1,14 @@
+from django.contrib.gis.db.backends.spatialite import base, features
+from django.db.backends.sqlite3 import base as sqlite_base
+
+from django_prometheus.db.common import DatabaseWrapperMixin
+
+
+class DatabaseFeatures(features.DatabaseFeatures):
+    """Our database has the exact same features as the base one."""
+
+    pass
+
+
+class DatabaseWrapper(DatabaseWrapperMixin, base.DatabaseWrapper):
+    CURSOR_CLASS = sqlite_base.SQLiteCursorWrapper

--- a/django_prometheus/tests/end2end/testapp/settings.py
+++ b/django_prometheus/tests/end2end/testapp/settings.py
@@ -81,6 +81,10 @@ DATABASES = {
         "HOST": "127.0.0.1",
         "PORT": "3306",
     },
+    "spatialite": {
+        "ENGINE": "django_prometheus.db.backends.spatialite",
+        "NAME": "db_spatialite.sqlite3",
+    },
     # The following databases are used by test_db.py only
     "test_db_1": {
         "ENGINE": "django_prometheus.db.backends.sqlite3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,13 @@ legacy_tox_ini = """
 [tox]
 min_version = 4.4
 envlist =
-    {py37,py38,py39,py310,py311}-django{320}-{end2end,unittests}
+    {py38,py39,py310,py311}-django{320}-{end2end,unittests}
     {py38,py39,py310,py311,py312}-django{400,410,420}-{end2end,unittests}
     {py310,py311,py312}-django{500,510}-{end2end,unittests}
     py39-lint
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39, py39-lint
     3.10: py310


### PR DESCRIPTION
This adds support for [SpatiaLite](https://docs.djangoproject.com/en/5.1/ref/contrib/gis/install/spatialite/) database backend.

Unfortunately, due to a [bug](https://stackoverflow.com/a/78349853) in SpatiaLite 5.0, the one that is supplied with Ubuntu 22.04, the database can not be properly initialized, which makes the e2e tests fail. That bug is fixed in SpatiLite 5.1, which is supplied with Ubuntu 24.04, hence the change to the runner OS.

With this change we are, however, not able to install Python 3.7 anymore, because it is no longer available for Ubuntu 24.04.

Since Python 3.7 is EOL, I think it's fine if we drop it from CI. If, however, we'd want to keep it, I'll have to figure out a way to install SpatiaLite on Ubuntu 22.04.