### PR TITLE
Support case where django-redis is not installed

### DIFF
--- a/django_prometheus/cache/backends/redis.py
+++ b/django_prometheus/cache/backends/redis.py
@@ -1,5 +1,4 @@
 from django import VERSION as DJANGO_VERSION
-from django_redis import cache, exceptions
 
 from django_prometheus.cache.metrics import (
     django_cache_get_fail_total,
@@ -8,29 +7,33 @@ from django_prometheus.cache.metrics import (
     django_cache_misses_total,
 )
 
+try:
+    from django_redis import cache, exceptions
 
-class RedisCache(cache.RedisCache):
-    """Inherit redis to add metrics about hit/miss/interruption ratio"""
+    class RedisCache(cache.RedisCache):
+        """Inherit redis to add metrics about hit/miss/interruption ratio"""
 
-    @cache.omit_exception
-    def get(self, key, default=None, version=None, client=None):
-        try:
-            django_cache_get_total.labels(backend="redis").inc()
-            cached = self.client.get(key, default=None, version=version, client=client)
-        except exceptions.ConnectionInterrupted as e:
-            django_cache_get_fail_total.labels(backend="redis").inc()
-            if self._ignore_exceptions:
-                if self._log_ignored_exceptions:
-                    cache.logger.error(str(e))
-                return default
-            raise
-        else:
-            if cached is not None:
-                django_cache_hits_total.labels(backend="redis").inc()
-                return cached
+        @cache.omit_exception
+        def get(self, key, default=None, version=None, client=None):
+            try:
+                django_cache_get_total.labels(backend="redis").inc()
+                cached = self.client.get(key, default=None, version=version, client=client)
+            except exceptions.ConnectionInterrupted as e:
+                django_cache_get_fail_total.labels(backend="redis").inc()
+                if self._ignore_exceptions:
+                    if self._log_ignored_exceptions:
+                        cache.logger.error(str(e))
+                    return default
+                raise
             else:
-                django_cache_misses_total.labels(backend="redis").inc()
-                return default
+                if cached is not None:
+                    django_cache_hits_total.labels(backend="redis").inc()
+                    return cached
+                else:
+                    django_cache_misses_total.labels(backend="redis").inc()
+                    return default
+except ImportError:
+    pass
 
 
 if DJANGO_VERSION >= (4, 0):


### PR DESCRIPTION
In order to support the case where django-redis is not installed make the definition of `RedisCache` conditional on successfully importing from `django_redis`.
This will allow a user to make use of `NativeRedisCache` without installing additional unnecessary dependencies.