### PR TITLE
Fix memcached return default on falsy values

### DIFF
--- a/django_prometheus/cache/backends/memcached.py
+++ b/django_prometheus/cache/backends/memcached.py
@@ -13,9 +13,10 @@ class MemcachedPrometheusCacheMixin:
         cached = super().get(key, default=None, version=version)
         if cached is not None:
             django_cache_hits_total.labels(backend="memcached").inc()
-        else:
-            django_cache_misses_total.labels(backend="memcached").inc()
-        return cached or default
+            return cached
+
+        django_cache_misses_total.labels(backend="memcached").inc()
+        return default
 
 
 class PyLibMCCache(MemcachedPrometheusCacheMixin, memcached.PyLibMCCache):


### PR DESCRIPTION
When a falsy value is returned from cache via memcached backend, it returns None (the default) instead, of the cached value.

This is the same issue as with the Redis backend, which was fixed here: https://github.com/korfuri/django-prometheus/commit/1860549c3f8db1a0175995826404561f760369e2