### PR TITLE
Only load django_redis when Django version is lower than 4

### DIFF
--- a/django_prometheus/cache/backends/redis.py
+++ b/django_prometheus/cache/backends/redis.py
@@ -1,5 +1,4 @@
 from django import VERSION as DJANGO_VERSION
-from django_redis import cache, exceptions
 
 from django_prometheus.cache.metrics import (
     django_cache_get_fail_total,
@@ -7,30 +6,6 @@ from django_prometheus.cache.metrics import (
     django_cache_hits_total,
     django_cache_misses_total,
 )
-
-
-class RedisCache(cache.RedisCache):
-    """Inherit redis to add metrics about hit/miss/interruption ratio"""
-
-    @cache.omit_exception
-    def get(self, key, default=None, version=None, client=None):
-        try:
-            django_cache_get_total.labels(backend="redis").inc()
-            cached = self.client.get(key, default=None, version=version, client=client)
-        except exceptions.ConnectionInterrupted as e:
-            django_cache_get_fail_total.labels(backend="redis").inc()
-            if self._ignore_exceptions:
-                if self._log_ignored_exceptions:
-                    cache.logger.error(str(e))
-                return default
-            raise
-        else:
-            if cached is not None:
-                django_cache_hits_total.labels(backend="redis").inc()
-                return cached
-            else:
-                django_cache_misses_total.labels(backend="redis").inc()
-                return default
 
 
 if DJANGO_VERSION >= (4, 0):
@@ -50,3 +25,29 @@ if DJANGO_VERSION >= (4, 0):
             else:
                 django_cache_misses_total.labels(backend="native_redis").inc()
                 return default
+else:
+    # Fallback for django_redis
+    from django_redis import cache, exceptions
+
+    class RedisCache(cache.RedisCache):
+        """Inherit redis to add metrics about hit/miss/interruption ratio"""
+    
+        @cache.omit_exception
+        def get(self, key, default=None, version=None, client=None):
+            try:
+                django_cache_get_total.labels(backend="redis").inc()
+                cached = self.client.get(key, default=None, version=version, client=client)
+            except exceptions.ConnectionInterrupted as e:
+                django_cache_get_fail_total.labels(backend="redis").inc()
+                if self._ignore_exceptions:
+                    if self._log_ignored_exceptions:
+                        cache.logger.error(str(e))
+                    return default
+                raise
+            else:
+                if cached is not None:
+                    django_cache_hits_total.labels(backend="redis").inc()
+                    return cached
+                else:
+                    django_cache_misses_total.labels(backend="redis").inc()
+                    return default


### PR DESCRIPTION
Avoid forcing users to install django_redis just to have this working.

Support for Django 4+ was added but the library django_redis is always loaded.