### PR TITLE
Drop Python 3.8 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as fl:
 
 
 def get_version():
-    version_file = open("django_prometheus/__init__.py", "r").read()
+    version_file = open("django_prometheus/__init__.py").read()
     version_match = re.search(
         r'^__version__ = [\'"]([^\'"]*)[\'"]', version_file, re.MULTILINE
     )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "Intended Audience :: Information Technology",
         "Intended Audience :: System Administrators",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 min_version = 4.4
 envlist =
-    {py38,py39,py310,py311,py312}-django420-{end2end,unittests}
+    {py39,py310,py311,py312}-django420-{end2end,unittests}
     {py310,py311,py312}-django{500,510}-{end2end,unittests}
     py39-lint
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39, py39-lint
     3.10: py310
     3.11: py311


### PR DESCRIPTION
Its EOL was Oct 2024: https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983