### PR TITLE
Update psycopg version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django-redis>=4.12.1
 prometheus-client>=0.12.0
 pip-prometheus>=1.2.1
 mysqlclient
-psycopg2
+psycopg
 pytest==7.4.3
 pytest-django
 pylibmc


### PR DESCRIPTION
Django is supporting psycopg>3 since Django 4.2

> Django supports PostgreSQL 12 and higher. psycopg 3.1.8+ or psycopg2 2.8.4+ is required, though the latest psycopg 3.1.8+ is recommended.

https://docs.djangoproject.com/en/4.2/ref/databases/#postgresql-notes

Resolves:
- https://github.com/korfuri/django-prometheus/issues/410

Supersedes 
- https://github.com/korfuri/django-prometheus/pull/377/