### PR TITLE
Fixed incompatibility with django-redis >= 4.12.0

### DIFF
--- a/django_prometheus/cache/backends/redis.py
+++ b/django_prometheus/cache/backends/redis.py
@@ -21,7 +21,7 @@ class RedisCache(cache.RedisCache):
             django_cache_get_fail_total.labels(backend="redis").inc()
             if self._ignore_exceptions:
                 if self._log_ignored_exceptions:
-                    cache.logger.error(str(e))
+                    self.logger.error(str(e))
                 return default
             raise
         else:


### PR DESCRIPTION
> Fixed bug caused by trying to use global level logger variable from django_redis.cache that has been moved to django_redis.cache.RedisCache instance attribute since django_redis 4.12.0 release.

Formatted version of https://github.com/korfuri/django-prometheus/pull/416

Depends on
- https://github.com/korfuri/django-prometheus/pull/461