### PR TITLE
Use pre-commit framework for linters & formatters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,3 @@ jobs:
         skip-existing: true
         verbose: true
         print-hash: true
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
+    hooks:
+    -   id: ruff-check
+        name: ruff check
+        args: ["--fix"]
+    -   id: ruff-format
+        name: ruff format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,14 @@
 repos:
 
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-case-conflict
+    -   id: check-merge-conflict
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+
 -   repo: https://github.com/adamchainz/django-upgrade
     rev: "1.25.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+
+-   repo: https://github.com/adamchainz/django-upgrade
+    rev: "1.25.0"
+    hooks:
+    -   id: django-upgrade
+        args: [--target-version, "4.2"]
+
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.13
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -199,4 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ with open("README.md") as fl:
 def get_version():
     version_file = open("django_prometheus/__init__.py").read()
     version_match = re.search(
-        r'^__version__ = [\'"]([^\'"]*)[\'"]', version_file, re.MULTILINE
+        r'^__version__ = [\'"]([^\'"]*)[\'"]',
+        version_file,
+        re.MULTILINE,
     )
     if version_match:
         return version_match.group(1)

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ commands =
 
 [testenv:py39-lint]
 deps =
-    ruff==0.11.13
+    pre-commit==4.2.0
 commands =
-    ruff format --check django_prometheus/
-    ruff check django_prometheus/
+    pre-commit run --all-files

--- a/update_version_from_git.py
+++ b/update_version_from_git.py
@@ -21,7 +21,6 @@ Get the branch/tag name with this.
     git symbolic-ref -q --short HEAD || git describe --tags --exact-match
 """
 
-import io
 import re
 import subprocess
 import sys
@@ -125,5 +124,6 @@ if __name__ == "__main__":
     else:
         print(
             "Invalid usage. Supply 0 or 1 arguments. "
-            "Argument can be either a version '1.2.3' or 'patch' if you want to increase the patch-version (1.2.3 -> 1.2.4.dev)"
+            "Argument can be either a version '1.2.3' or 'patch' "
+            "if you want to increase the patch-version (1.2.3 -> 1.2.4.dev)"
         )


### PR DESCRIPTION
Wraps `ruff` with pre-commit, adds basic pre-commit hooks and `django-upgrade`.