### PR TITLE
Add Python 3.14 and 3.14t to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
@@ -45,17 +45,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install binutils libproj-dev gdal-bin libmemcached-dev libsqlite3-mod-spatialite
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U "pip>=23.1.1"
-          pip install -U "tox-gh-actions==3.3.0" coverage
+          pip install --upgrade "pip>=23.1.1"
+          pip install --upgrade "tox-gh-actions==3.3.0" coverage
       - name: Log versions
         run: |
           python --version
@@ -69,8 +69,8 @@ jobs:
           PGHOST: localhost
           PGPORT: 5432
         run: |
-          psql -U postgres -c 'CREATE DATABASE postgis'
-          psql -U postgres postgis -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+          psql --user postgres -c 'CREATE DATABASE postgis'
+          psql --user postgres postgis -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
           mysql --protocol=TCP --user=root -e 'create database django_prometheus_1;'
       - name: Run test and linters via Tox
         run: tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.5.0 - UNRELEASED
 
 * Drop support for Django 5.0 (EOL)
+* Add support for Python 3.13, 3.14, and free threaded 3.14t.
 
 ## v2.4.1 - June 25th, 2025
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.14t",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ min_version = 4.4
 envlist =
     {py39,py310,py311,py312}-django420-{end2end,unittests}
     {py310,py311,py312,py313}-django{510,520}-{end2end,unittests}
+    {py314,py314t}-django520-{end2end,unittests}
     py39-lint
+skip_missing_interpreters = True
 
 [gh-actions]
 python =
@@ -12,6 +14,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314,py314t
 
 [testenv]
 deps =


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

---
`pip install -U` can be quite opaque to readers because pip install currently has six `--u*` options, including `--user`.

`pip install --upgrade` makes the intention clearer in code that others will read.

% `python3 -m pip install --help | grep "\-\-u"`
```
  --user                      Install to the Python user install directory for
  -U, --upgrade               Upgrade all specified packages to the newest
  --upgrade-strategy <upgrade_strategy>
  --use-pep517                Use PEP 517 for building source distributions
  --use-feature <feature>     Enable new functionality, that may be backward
  --use-deprecated <feature>  Enable deprecated functionality, that will be
``` 
@asherf 