### PR TITLE
add setting PROMETHEUS_TOTAL_BYTES_BUCKETS for metric body size

### DIFF
--- a/django_prometheus/conf/__init__.py
+++ b/django_prometheus/conf/__init__.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django_prometheus.utils import PowersOf
 
 NAMESPACE = ""
 
@@ -22,6 +23,9 @@ PROMETHEUS_LATENCY_BUCKETS = (
     float("inf"),
 )
 
+PROMETHEUS_TOTAL_BYTES_BUCKETS = PowersOf(2, 30)
+
 if settings.configured:
     NAMESPACE = getattr(settings, "PROMETHEUS_METRIC_NAMESPACE", NAMESPACE)
     PROMETHEUS_LATENCY_BUCKETS = getattr(settings, "PROMETHEUS_LATENCY_BUCKETS", PROMETHEUS_LATENCY_BUCKETS)
+    PROMETHEUS_TOTAL_BYTES_BUCKETS = getattr(settings, "PROMETHEUS_TOTAL_BYTES_BUCKETS", PROMETHEUS_TOTAL_BYTES_BUCKETS)

--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -1,8 +1,8 @@
 from django.utils.deprecation import MiddlewareMixin
 from prometheus_client import Counter, Histogram
 
-from django_prometheus.conf import NAMESPACE, PROMETHEUS_LATENCY_BUCKETS
-from django_prometheus.utils import PowersOf, Time, TimeSince
+from django_prometheus.conf import NAMESPACE, PROMETHEUS_LATENCY_BUCKETS, PROMETHEUS_TOTAL_BYTES_BUCKETS
+from django_prometheus.utils import Time, TimeSince
 
 
 class Metrics:
@@ -96,7 +96,7 @@ class Metrics:
             Histogram,
             "django_http_requests_body_total_bytes",
             "Histogram of requests by body size.",
-            buckets=PowersOf(2, 30),
+            buckets=PROMETHEUS_TOTAL_BYTES_BUCKETS,
             namespace=NAMESPACE,
         )
         # Set in process_template_response
@@ -126,7 +126,7 @@ class Metrics:
             Histogram,
             "django_http_responses_body_total_bytes",
             "Histogram of responses by body size.",
-            buckets=PowersOf(2, 30),
+            buckets=PROMETHEUS_TOTAL_BYTES_BUCKETS,
             namespace=NAMESPACE,
         )
         self.responses_by_charset = self.register_metric(


### PR DESCRIPTION
Hi
At work, I encountered a problem where our service has a release limitation due to the large number of buckets in some metrics. This limitation is due to the fact that a large number of buckets puts a heavy load on Prometheus.

More specifically, django_http_requests_body_total_bytes and django_http_responses_body_total_bytes
This is despite the fact that starting with le=2^17 in django_http_requests_body_total_bytes_bucket and le=2^24 in django_http_responses_body_total_bytes_bucket, there is no difference.
In fact, the difference between le=2^24 and le=2^17 in django_http_requests_body_total_bytes_bucket is 16 for 320k requests.

I propose enabling custom bucket sizes.