### PR TITLE
Use multiprocess_mode max for migrations Gauges

### DIFF
--- a/django_prometheus/migrations.py
+++ b/django_prometheus/migrations.py
@@ -9,6 +9,7 @@ unapplied_migrations = Gauge(
     "Count of unapplied migrations by database connection",
     ["connection"],
     namespace=NAMESPACE,
+    multiprocess_mode='max',
 )
 
 applied_migrations = Gauge(
@@ -16,6 +17,7 @@ applied_migrations = Gauge(
     "Count of applied migrations by database connection",
     ["connection"],
     namespace=NAMESPACE,
+    multiprocess_mode='max',
 )
 
 


### PR DESCRIPTION
By default, when using prometheus client in a multiprocess mode, Gauges
export a separate time series per pid. For migrations gauges, it makes
more sense to have a single timeseries for all processes, calculated by
taking a maximum of all values.

Closes #498 