### PR TITLE
Bump the pre-release version for 2.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v2.5.0 - UNRELEASED
 
-* Drop support for Django 5.0 (EOL)
+* Add support for Django 5.2 and 6.0.
+* Drop support for Django 5.0 (EOL).
 * Add support for Python 3.13, 3.14, and free threaded 3.14t.
 
 ## v2.4.1 - June 25th, 2025

--- a/django_prometheus/__init__.py
+++ b/django_prometheus/__init__.py
@@ -10,7 +10,7 @@ from django_prometheus import middleware, models
 
 __all__ = ["middleware", "models", "pip_prometheus"]
 
-__version__ = "2.5.0.dev0"
+__version__ = "2.5.0.dev1"
 
 # Import pip_prometheus to export the pip metrics automatically.
 try:


### PR DESCRIPTION
This also includes a changelog entry about support for Django 5.2 and 6.0.

Feel free to close this issue. I figured I could help do some of the grunt work. I believe merging this will retrigger the prerelease workflow with the new version to confirm that 2.5.0 is good to go.